### PR TITLE
Improve SourcesTreeItem.mapStateToProps performance by storing plain urls

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -260,7 +260,7 @@ function updatePlainUrl(state: SourcesState, source: Object) {
   if (!source.url || state.urls[source.url]) {
     return;
   }
-  const plainUrl = source.url.split("?")[0];
+  const plainUrl = getPlainUrl(source.url);
   const existing = state.plainUrls[plainUrl] || [];
   state.plainUrls[plainUrl] = [...existing, source.url];
 }
@@ -568,6 +568,11 @@ function getSourcesByUrlInSources(
   return urls[url].map(id => sources[id]);
 }
 
+function getPlainUrl(url: string): string {
+  const queryStart = url.indexOf("?");
+  return queryStart !== -1 ? url.slice(0, queryStart) : url;
+}
+
 export function getSourcesUrlsInSources(
   state: OuterState,
   url: string
@@ -575,7 +580,7 @@ export function getSourcesUrlsInSources(
   if (!url) {
     return [];
   }
-  const plainUrl = url.split("?")[0];
+  const plainUrl = getPlainUrl(url);
   const plainUrls = getPlainUrls(state);
   return plainUrls[plainUrl] || [];
 }


### PR DESCRIPTION
Without storing them, every visible tree item does the same work of trimming query parameters from every URL, which gets expensive pretty quickly.

I ended up not using reselect because it didn't seem like a good fit - there's no way to know what changed, so you'd have to rebuild the entire plain URL map every time the URL map changed.

For testing, I navigated the debuggee to https://wartmanm.github.io/debugger-benchmarks/500-scripts.html, made sure the source list in the debugger was fully expanded, and profiled adding a watch expression of "1 + 1".

Before: https://perfht.ml/2Sj4MvH
After: https://perfht.ml/2SgTfNz

I'd like to tackle getHasMatchingGeneratedSource and checkHasPrettySource as well, but this has a much bigger impact.