### PR TITLE
Add a BigInt rep.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-render-roots-in-reps.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-render-roots-in-reps.js
@@ -12,6 +12,7 @@ const gripStubs = require("../../../reps/stubs/grip");
 const gripArrayStubs = require("../../../reps/stubs/grip-array");
 const symbolStubs = require("../../../reps/stubs/symbol");
 const errorStubs = require("../../../reps/stubs/error");
+const bigIntStubs = require("../../../reps/stubs/big-int");
 
 describe("shouldRenderRootsInReps", () => {
   it("returns true for a string", () => {
@@ -29,6 +30,16 @@ describe("shouldRenderRootsInReps", () => {
       shouldRenderRootsInReps([
         {
           contents: { value: numberStubs.get("Int") }
+        }
+      ])
+    ).toBeTruthy();
+  });
+
+  it("returns true for a big int", () => {
+    expect(
+      shouldRenderRootsInReps([
+        {
+          contents: { value: bigIntStubs.get("1n") }
         }
       ])
     ).toBeTruthy();

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -10,6 +10,7 @@ const GripArrayRep = require("../../reps/grip-array");
 const GripMap = require("../../reps/grip-map");
 const GripMapEntryRep = require("../../reps/grip-map-entry");
 const ErrorRep = require("../../reps/error");
+const BigIntRep = require("../../reps/big-int");
 const { isLongString } = require("../../reps/string");
 
 const MAX_NUMERICAL_PROPERTIES = 100;
@@ -162,13 +163,14 @@ function nodeHasProperties(item: Node): boolean {
 
 function nodeIsPrimitive(item: Node): boolean {
   return (
-    !nodeHasChildren(item) &&
-    !nodeHasProperties(item) &&
-    !nodeIsEntries(item) &&
-    !nodeIsMapEntry(item) &&
-    !nodeHasAccessors(item) &&
-    !nodeIsBucket(item) &&
-    !nodeIsLongString(item)
+    nodeIsBigInt(item) ||
+    (!nodeHasChildren(item) &&
+      !nodeHasProperties(item) &&
+      !nodeIsEntries(item) &&
+      !nodeIsMapEntry(item) &&
+      !nodeHasAccessors(item) &&
+      !nodeIsBucket(item) &&
+      !nodeIsLongString(item))
   );
 }
 
@@ -229,6 +231,10 @@ function nodeIsError(item: Node): boolean {
 
 function nodeIsLongString(item: Node): boolean {
   return isLongString(getValue(item));
+}
+
+function nodeIsBigInt(item: Node): boolean {
+  return BigIntRep.supportsObject(getValue(item));
 }
 
 function nodeHasFullText(item: Node): boolean {

--- a/packages/devtools-reps/src/reps/big-int.js
+++ b/packages/devtools-reps/src/reps/big-int.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// Dependencies
+const PropTypes = require("prop-types");
+
+const { getGripType, wrapRender } = require("./rep-utils");
+
+const dom = require("react-dom-factories");
+const { span } = dom;
+
+/**
+ * Renders a number
+ */
+BigInt.propTypes = {
+  object: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number,
+    PropTypes.bool
+  ]).isRequired
+};
+
+function BigInt(props) {
+  const { text } = props.object;
+
+  return span({ className: "objectBox objectBox-number" }, `${text}n`);
+}
+
+function supportsObject(object, noGrip = false) {
+  return getGripType(object, noGrip) === "BigInt";
+}
+
+// Exports from this module
+
+module.exports = {
+  rep: wrapRender(BigInt),
+  supportsObject
+};

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -19,6 +19,7 @@ const Accessor = require("./accessor");
 // DOM types (grips)
 const Accessible = require("./accessible");
 const Attribute = require("./attribute");
+const BigInt = require("./big-int");
 const DateTime = require("./date-time");
 const Document = require("./document");
 const DocumentType = require("./document-type");
@@ -69,6 +70,7 @@ const reps = [
   Null,
   StringRep,
   Number,
+  BigInt,
   SymbolRep,
   InfinityRep,
   NaNRep,
@@ -129,6 +131,7 @@ module.exports = {
     Accessor,
     ArrayRep,
     Attribute,
+    BigInt,
     CommentNode,
     DateTime,
     Document,

--- a/packages/devtools-reps/src/reps/stubs/big-int.js
+++ b/packages/devtools-reps/src/reps/stubs/big-int.js
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+const stubs = new Map();
+stubs.set("1n", {
+  type: "BigInt",
+  text: "1"
+});
+
+stubs.set("-2n", {
+  type: "BigInt",
+  text: "-2"
+});
+
+stubs.set("0n", {
+  type: "BigInt",
+  text: "0"
+});
+
+stubs.set("[1n,-2n,0n]", {
+  type: "object",
+  actor: "server1.conn15.child1/obj27",
+  class: "Array",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  ownPropertyLength: 4,
+  preview: {
+    kind: "ArrayLike",
+    length: 3,
+    items: [
+      {
+        type: "BigInt",
+        text: "1"
+      },
+      {
+        type: "BigInt",
+        text: "-2"
+      },
+      {
+        type: "BigInt",
+        text: "0"
+      }
+    ]
+  }
+});
+
+stubs.set("new Set([1n,-2n,0n])", {
+  type: "object",
+  actor: "server1.conn15.child1/obj29",
+  class: "Set",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  ownPropertyLength: 0,
+  preview: {
+    kind: "ArrayLike",
+    length: 3,
+    items: [
+      {
+        type: "BigInt",
+        text: "1"
+      },
+      {
+        type: "BigInt",
+        text: "-2"
+      },
+      {
+        type: "BigInt",
+        text: "0"
+      }
+    ]
+  }
+});
+
+stubs.set("new Map([ [1n, -1n], [-2n, 0n], [0n, -2n]])", {
+  type: "object",
+  actor: "server1.conn15.child1/obj32",
+  class: "Map",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  ownPropertyLength: 0,
+  preview: {
+    kind: "MapLike",
+    size: 3,
+    entries: [
+      [
+        {
+          type: "BigInt",
+          text: "1"
+        },
+        {
+          type: "BigInt",
+          text: "-1"
+        }
+      ],
+      [
+        {
+          type: "BigInt",
+          text: "-2"
+        },
+        {
+          type: "BigInt",
+          text: "0"
+        }
+      ],
+      [
+        {
+          type: "BigInt",
+          text: "0"
+        },
+        {
+          type: "BigInt",
+          text: "-2"
+        }
+      ]
+    ]
+  }
+});
+
+stubs.set("({simple: 1n, negative: -2n, zero: 0n})", {
+  type: "object",
+  actor: "server1.conn15.child1/obj34",
+  class: "Object",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  ownPropertyLength: 3,
+  preview: {
+    kind: "Object",
+    ownProperties: {
+      simple: {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: {
+          type: "BigInt",
+          text: "1"
+        }
+      },
+      negative: {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: {
+          type: "BigInt",
+          text: "-2"
+        }
+      },
+      zero: {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: {
+          type: "BigInt",
+          text: "0"
+        }
+      }
+    },
+    ownSymbols: [],
+    ownPropertiesLength: 3,
+    ownSymbolsLength: 0,
+    safeGetterValues: {}
+  }
+});
+
+stubs.set("Promise.resolve(1n)", {
+  type: "object",
+  actor: "server1.conn15.child1/obj36",
+  class: "Promise",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  promiseState: {
+    state: "fulfilled",
+    value: {
+      type: "BigInt",
+      text: "1"
+    },
+    creationTimestamp: 1550831461773.1665,
+    timeToSettle: 0.036448000464588404
+  },
+  ownPropertyLength: 0,
+  preview: {
+    kind: "Object",
+    ownProperties: {},
+    ownSymbols: [],
+    ownPropertiesLength: 0,
+    ownSymbolsLength: 0,
+    safeGetterValues: {}
+  }
+});
+
+module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/big-int.js
+++ b/packages/devtools-reps/src/reps/tests/big-int.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+const { shallow } = require("enzyme");
+const { REPS, getRep } = require("../rep");
+const { BigInt, Rep } = REPS;
+const stubs = require("../stubs/big-int");
+
+describe("BigInt", () => {
+  describe("1n", () => {
+    const stub = stubs.get("1n");
+
+    it("correctly selects BigInt Rep for BigInt value", () => {
+      expect(getRep(stub)).toBe(BigInt.rep);
+    });
+
+    it("renders with expected text content for BigInt", () => {
+      const renderedComponent = shallow(
+        Rep({
+          object: stub
+        })
+      );
+
+      expect(renderedComponent.text()).toEqual("1n");
+    });
+  });
+
+  describe("-2n", () => {
+    const stub = stubs.get("-2n");
+
+    it("correctly selects BigInt Rep for negative BigInt value", () => {
+      expect(getRep(stub)).toBe(BigInt.rep);
+    });
+
+    it("renders with expected text content for negative BigInt", () => {
+      const renderedComponent = shallow(
+        Rep({
+          object: stub
+        })
+      );
+
+      expect(renderedComponent.text()).toEqual("-2n");
+    });
+  });
+
+  describe("0n", () => {
+    const stub = stubs.get("0n");
+
+    it("correctly selects BigInt Rep for zero BigInt value", () => {
+      expect(getRep(stub)).toBe(BigInt.rep);
+    });
+
+    it("renders with expected text content for zero BigInt", () => {
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual("0n");
+    });
+  });
+
+  describe("in objects", () => {
+    it("renders with expected text content in Array", () => {
+      const stub = stubs.get("[1n,-2n,0n]");
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual("Array(3) [ 1n, -2n, 0n ]");
+    });
+
+    it("renders with expected text content in Set", () => {
+      const stub = stubs.get("new Set([1n,-2n,0n])");
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual("Set(3) [ 1n, -2n, 0n ]");
+    });
+
+    it("renders with expected text content in Map", () => {
+      const stub = stubs.get("new Map([ [1n, -1n], [-2n, 0n], [0n, -2n]])");
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual(
+        "Map(3) { 1n → -1n, -2n → 0n, 0n → -2n }"
+      );
+    });
+
+    it("renders with expected text content in Object", () => {
+      const stub = stubs.get("({simple: 1n, negative: -2n, zero: 0n})");
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual(
+        "Object { simple: 1n, negative: -2n, zero: 0n }"
+      );
+    });
+
+    it("renders with expected text content in Promise", () => {
+      const stub = stubs.get("Promise.resolve(1n)");
+      const renderedComponent = shallow(Rep({ object: stub }));
+      expect(renderedComponent.text()).toEqual(
+        'Promise { <state>: "fulfilled", <value>: 1n }'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #7974.

The server will send a grip of the following shape: 

```json
{
  "type": "BigInt",
  "value": "1",
}
```
where `value` is `myBigInt.toString()` (we can send the actual BigInt as they're not serializable).

We can display it by taking `value` and appending `n` to it (e.g. `1n`).
