### PR TITLE
added no sources message in Sources Pane

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -335,7 +335,7 @@ class SourcesTree extends Component<Props, State> {
     return this.renderPane(
       this.renderThreadHeader(),
       this.isEmpty() ? (
-        this.renderEmptyElement("No Sources")
+        this.renderEmptyElement(L10N.getStr("noSourcesText"))
       ) : (
         <div key="tree" className="sources-list">
           {this.renderTree()}

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -334,9 +334,13 @@ class SourcesTree extends Component<Props, State> {
 
     return this.renderPane(
       this.renderThreadHeader(),
-      <div key="tree" className="sources-list">
-        {this.renderTree()}
-      </div>
+      this.isEmpty() ? (
+        this.renderEmptyElement("No Sources")
+      ) : (
+        <div key="tree" className="sources-list">
+          {this.renderTree()}
+        </div>
+      )
     );
   }
 }

--- a/src/components/PrimaryPanes/tests/SourcesTree.spec.js
+++ b/src/components/PrimaryPanes/tests/SourcesTree.spec.js
@@ -28,6 +28,14 @@ describe("SourcesTree", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("Should show a 'No Sources' message if there are no sources", async () => {
+    const { component, defaultState } = render();
+    const sourceTree = defaultState.sourceTree;
+    sourceTree.contents = [];
+    component.setState({ sourceTree: sourceTree });
+    expect(component).toMatchSnapshot();
+  });
+
   describe("When loading initial source", () => {
     it("Shows the tree with one.js, two.js and three.js expanded", async () => {
       const { component, props } = render();

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
@@ -69,7 +69,7 @@ exports[`SourcesTree Should show a 'No Sources' message if there are no sources 
     className="no-sources-message"
     key="empty"
   >
-    No Sources
+    This page has no sources.
   </div>
 </div>
 `;

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
@@ -48,6 +48,20 @@ exports[`SourcesTree After changing expanded nodes Shows the tree with four.js, 
 </div>
 `;
 
+exports[`SourcesTree Should show a 'No Sources' message if there are no sources 1`] = `
+<div
+  className="sources-pane"
+  key="pane"
+>
+  <div
+    className="no-sources-message"
+    key="empty"
+  >
+    No Sources
+  </div>
+</div>
+`;
+
 exports[`SourcesTree Should show the tree with nothing expanded 1`] = `
 <div
   className="sources-pane thread"

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTree.spec.js.snap
@@ -50,9 +50,21 @@ exports[`SourcesTree After changing expanded nodes Shows the tree with four.js, 
 
 exports[`SourcesTree Should show a 'No Sources' message if there are no sources 1`] = `
 <div
-  className="sources-pane"
+  className="sources-pane thread"
   key="pane"
 >
+  <div
+    className="node thread-header"
+  >
+    <AccessibleImage
+      className="file"
+    />
+    <span
+      className="label"
+    >
+      Main Thread
+    </span>
+  </div>
   <div
     className="no-sources-message"
     key="empty"


### PR DESCRIPTION
Fixes #7966

### Summary of Changes

* Added a "No Sources" message in the sources pane when there are no sources on a page
