### PR TITLE
[Breakpoints] Fix color for disabled conditional breakpoints and logpoints

### DIFF
--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -18,17 +18,13 @@
   height: 13px;
   width: 11px;
   vertical-align: top;
-}
-
-.column-breakpoint.active svg {
-  fill: var(--blue-50);
+  fill: var(--blue-40);
   stroke: var(--blue-60);
 }
 
 .column-breakpoint.disabled svg {
-  fill: var(--blue-50);
-  stroke: var(--blue-40);
-  fill-opacity: 0.5;
+  fill-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 
 .column-breakpoint.has-condition svg {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -58,16 +58,12 @@ html[dir="rtl"] .editor-mount {
   --gutter-hover-background-color: #dde1e4;
   --breakpoint-fill: var(--blue-50);
   --breakpoint-stroke: var(--blue-60);
-  --breakpoint-fill-disabled: var(--blue-50);
-  --breakpoint-stroke-disabled: var(--blue-40);
 }
 
 .theme-dark {
   --gutter-hover-background-color: #414141;
   --breakpoint-fill: var(--blue-55);
   --breakpoint-stroke: var(--blue-40);
-  --breakpoint-fill-disabled: var(--blue-50);
-  --breakpoint-stroke-disabled: var(--blue-60);
 }
 
 .theme-light .cm-s-mozilla .empty-line .CodeMirror-linenumber {
@@ -163,8 +159,6 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {
-  fill: var(--breakpoint-fill-disabled);
-  stroke: var(--breakpoint-stroke-disabled);
   fill-opacity: 0.5;
 }
 

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -159,18 +159,8 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {
-  fill-opacity: 0.5;
-}
-
-.editor.column-breakpoint svg {
-  fill: var(--theme-selection-background);
-  vertical-align: middle;
-  width: 17px;
-  height: 15px;
-}
-
-.editor.column-breakpoint.breakpoint-disabled svg {
-  opacity: 0.3;
+  fill-opacity: 0.7;
+  stroke-opacity: 0.7;
 }
 
 .CodeMirror {


### PR DESCRIPTION
Fixes #8004 

### Summary of Changes

* Deleted 2 CSS properties on disabled breakpoints that were changing the color of all disabled breakpoints/logpoints to blue
* Also deleted the CSS variables related to the deleted CSS properties because they are now unused
* Note that this change helps fix both conditional breakpoints and conditional logpoints. Works in both light and dark theme

### Demo
![disabled-breakpoint-color](https://user-images.githubusercontent.com/21224637/53126260-8fd17e00-3514-11e9-8db9-a373d97cf813.gif)



