### PR TITLE
Update community call link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Say hello in [Slack][slack] or in the [#devtools-html][irc-devtools-html] channe
 [help]: ./docs/local-development.md#getting-help
 [participation guidelines]: https://www.mozilla.org/en-US/about/governance/policies/participation/
 [irc-devtools-html]: irc://irc.mozilla.org/devtools-html
-[community-call]: https://appear.in/debugger.html
+[community-call]: https://appear.in/firefox-debugger
 [devtools-call]: https://wiki.mozilla.org/DevTools
 [bugzilla]: https://bugzilla.mozilla.org/query.cgi
 [vulnerabilities]: https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/


### PR DESCRIPTION
Updates the community call link to reflect the new appear.in room (https://appear.in/firefox-debugger), as discussed with @jasonLaster in PR #8018.

Jason's comment can be viewed here:

https://github.com/firefox-devtools/debugger/pull/8018#issuecomment-466485945

### Summary of Changes

* Changed community call link to https://appear.in/firefox-debugger