### PR TITLE
Docs update: debugging-the-debugger.md

### DIFF
--- a/docs/debugging-the-debugger.md
+++ b/docs/debugging-the-debugger.md
@@ -24,7 +24,8 @@ Let's design a new theme for the debugger—don't worry, it's not so hard!
 
 - Don't forget to read about the [themes](local-development.md#themes).
 - Remember that each component has its own CSS.
-- Keep in mind that there is a CSS file for variables.
+- Keep in mind that there is a CSS file for variables: 
+  ~/debugger/node_modules/devtools-mc-assets/assets/devtools/client/themes/variables.css  
 - Take a look at the "reps"— a set of rules for the debugger!
 
 **Next Steps**


### PR DESCRIPTION
Added file name for the CSS variables file, which is in node_modules, and not immediately apparent.
Maybe helpful for newbies like me!

Fixes #<issue number>

Here's the Pull Request Doc
https://firefox-dev.tools/debugger/docs/pull-requests.html

### Summary of Changes

* Added path for CSS variables:
~/debugger/node_modules/devtools-mc-assets/assets/devtools/client/themes/variables.css

### Test Plan

Tell us a little a bit about how you tested your patch.

This is my first PR - thanks for any advice/help on testing!
Don't think I need to run any tests for this basic doc update?

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
