### PR TITLE
Reorder Source Tree (Origins, Webpack, Extensions)

### DIFF
--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -6,7 +6,12 @@
 
 import { parse } from "../url";
 
-import { nodeHasChildren, isNgBundler, isWebpackBundler, isExactDomainMatch } from "./utils";
+import {
+  nodeHasChildren,
+  isNgBundler,
+  isWebpackBundler,
+  isExactDomainMatch
+} from "./utils";
 import { isUrlExtension } from "../source";
 
 import type { TreeNode } from "./types";

--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -6,7 +6,7 @@
 
 import { parse } from "../url";
 
-import { nodeHasChildren } from "./utils";
+import { nodeHasChildren, isNgBundler, isWebpackBundler, isExactDomainMatch } from "./utils";
 import { isUrlExtension } from "../source";
 
 import type { TreeNode } from "./types";
@@ -26,23 +26,6 @@ export function getDomain(url?: string): ?string {
     return null;
   }
   return host.startsWith("www.") ? host.substr("www.".length) : host;
-}
-
-/*
- * Checks if node name matches debugger host/domain.
- */
-function isExactDomainMatch(part: string, debuggeeHost: string): boolean {
-  return part.startsWith("www.")
-    ? part.substr("www.".length) === debuggeeHost
-    : part === debuggeeHost;
-}
-
-function isNgBundler(part: string): boolean {
-  return part === "ng://";
-}
-
-function isWebpackBundler(part: string): boolean {
-  return part === "webpack://";
 }
 
 /*

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -133,3 +133,26 @@ export function getRelativePath(url: string) {
   path.shift();
   return path.join("/");
 }
+
+/*
+ * Checks if node name matches debugger host/domain.
+ */
+export function isExactDomainMatch(part: string, debuggeeHost: string): boolean {
+  return part.startsWith("www.")
+    ? part.substr("www.".length) === debuggeeHost
+    : part === debuggeeHost;
+}
+
+/*
+ * Checks if node name matches Angular Bundler.
+ */
+export function isNgBundler(part: string): boolean {
+  return part === "ng://";
+}
+
+/*
+ * Checks if node name matches Webpack Bundler.
+ */
+export function isWebpackBundler(part: string): boolean {
+  return part === "webpack://";
+}

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -137,7 +137,10 @@ export function getRelativePath(url: string) {
 /*
  * Checks if node name matches debugger host/domain.
  */
-export function isExactDomainMatch(part: string, debuggeeHost: string): boolean {
+export function isExactDomainMatch(
+  part: string,
+  debuggeeHost: string
+): boolean {
   return part.startsWith("www.")
     ? part.substr("www.".length) === debuggeeHost
     : part === debuggeeHost;


### PR DESCRIPTION
Fixes #7921 

### Summary of Changes

* Reorder function which orders the webpack and extensions at the end of the sourceTree
