### PR TITLE
Update setPreview to properly display falsy values in preview tooltip

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -104,10 +104,6 @@ export function setPreview(
           thread: selectedFrame.thread
         });
 
-        if (!result) {
-          return;
-        }
-
         return {
           expression,
           result,


### PR DESCRIPTION
Fixes #7956 

### Summary of Investigation
Investigated the issue and found that it applied to other falsy values, such as `0` and `''`.
![falsy_preview_demo](https://user-images.githubusercontent.com/21224637/53375047-06082300-390f-11e9-9ea4-c2f00273d7b8.gif)

Within `src/actions/preview.js` we have a piece of code that exits/returns from `setPreview` when the `result` of evaluating the `expression` is a falsy value.

This code originated from PR [#3363](https://github.com/firefox-devtools/debugger/pull/3363). It looks like the use case for this code might be to exit `setPreview` if the `expression` evaluates to something undesired. However, it's also the reason we see unintended behavior with certain falsy values. I  deleted this code to fix the issue.

### Demo of Fix
![falsy_preview_solution_demo](https://user-images.githubusercontent.com/21224637/53375193-60a17f00-390f-11e9-8596-4730f0f9c21b.gif)

Let me know what you think and if there is anything I can improve, thank you!
