### PR TITLE
Add focus-within for showing breakpoint's delete button

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -135,7 +135,7 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoints-list .breakpoint:hover .breakpoint-line,
-.breakpoints-list .breakpoint:focus-within .breakpoint-line {
+.A11y-keyboard .breakpoints-list .breakpoint:focus-within .breakpoint-line {
   color: transparent;
 }
 
@@ -188,7 +188,7 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint:hover .close-btn,
-.breakpoint:focus-within .close-btn {
+.A11y-keyboard .breakpoint:focus-within .close-btn {
   display: flex;
 }
 
@@ -197,7 +197,7 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint:hover .close,
-.breakpoint:focus-within .close {
+.A11y-keyboard .breakpoint:focus-within .close {
   visibility: visible;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -56,6 +56,7 @@
 
 .breakpoints-list .breakpoint {
   min-height: var(--breakpoint-expression-height);
+  overflow: hidden;
 }
 
 .breakpoints-exceptions-caught {
@@ -134,8 +135,7 @@ html .breakpoints-list .breakpoint.paused {
   text-align: end;
 }
 
-.breakpoints-list .breakpoint:hover .breakpoint-line,
-.A11y-keyboard .breakpoints-list .breakpoint:focus-within .breakpoint-line {
+.breakpoints-list .breakpoint:hover .breakpoint-line {
   color: transparent;
 }
 
@@ -183,22 +183,12 @@ html .breakpoints-list .breakpoint.paused {
   inset-inline-end: 15px;
   inset-inline-start: auto;
   position: absolute;
-  top: 8px;
-  display: none;
+  top: -100px;
 }
 
 .breakpoint:hover .close-btn,
-.A11y-keyboard .breakpoint:focus-within .close-btn {
-  display: flex;
-}
-
-.breakpoint .close {
-  visibility: hidden;
-}
-
-.breakpoint:hover .close,
-.A11y-keyboard .breakpoint:focus-within .close {
-  visibility: visible;
+.close-btn:focus {
+  top: 25%;
 }
 
 .CodeMirror.cm-s-mozilla-breakpoint {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -134,7 +134,8 @@ html .breakpoints-list .breakpoint.paused {
   text-align: end;
 }
 
-.breakpoints-list .breakpoint:hover .breakpoint-line {
+.breakpoints-list .breakpoint:hover .breakpoint-line,
+.breakpoints-list .breakpoint:focus-within .breakpoint-line {
   color: transparent;
 }
 
@@ -186,7 +187,8 @@ html .breakpoints-list .breakpoint.paused {
   display: none;
 }
 
-.breakpoint:hover .close-btn {
+.breakpoint:hover .close-btn,
+.breakpoint:focus-within .close-btn {
   display: flex;
 }
 
@@ -194,7 +196,8 @@ html .breakpoints-list .breakpoint.paused {
   visibility: hidden;
 }
 
-.breakpoint:hover .close {
+.breakpoint:hover .close,
+.breakpoint:focus-within .close {
   visibility: visible;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -183,12 +183,12 @@ html .breakpoints-list .breakpoint.paused {
   inset-inline-end: 15px;
   inset-inline-start: auto;
   position: absolute;
-  top: -100px;
+  top: -100px; /*For hiding button outside of row until hovered or focused*/
 }
 
 .breakpoint:hover .close-btn,
-.close-btn:focus {
-  top: 25%;
+.breakpoint .close-btn:focus {
+  top: calc(50% - 8px);
 }
 
 .CodeMirror.cm-s-mozilla-breakpoint {


### PR DESCRIPTION
Fixes #8012

I keep the `:hover` feature intact for users using a mouse. I added `:focus-with` for keyboard users. I'm new to accessibility practices, so I'd like to listen to feedback and follow up with the discussion. After deciding for breakpoints, we should keep the behavior consistent for watch expressions' delete button.

### Summary of Changes
* Added :focus-within property

### Screenshots/Videos
1) Hovering the label: delete button displays; mouse out: delete button hides.
![1emghuu7cu](https://user-images.githubusercontent.com/38041280/53380552-c572ce80-393b-11e9-83a2-1e7162de933b.gif)

2) Using tab. Tabbing to the check box: delete button displays; tab out: button hides.
![w0hyppvl46](https://user-images.githubusercontent.com/38041280/53380614-023ec580-393c-11e9-956c-f9ee8470cb75.gif)

3) One potential "side effect": I use the mouse to check off the box then move my mouse out. Since the checkbox is still in focus, the delete buttons still shows. I need to click somewhere else to get the checkbox out of focus, then delete button can hide. Not sure if it's a problem.
![mn5camkubc](https://user-images.githubusercontent.com/38041280/53381808-fd7c1080-393f-11e9-907d-125637e9e418.gif)