### PR TITLE
Add search modifiers in Search | Fix #7967

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -21,6 +21,7 @@ import {
 
 import type { Action, ThunkArgs } from "./types";
 import type { SearchOperation } from "../reducers/project-text-search";
+import type { SearchModifiers } from "../../types";
 
 export function addSearchQuery(query: string): Action {
   return { type: "ADD_QUERY", query };
@@ -72,7 +73,7 @@ export function stopOngoingSearch() {
   };
 }
 
-export function searchSources(query: string) {
+export function searchSources(query: string, modifiers: SearchModifiers) {
   let cancelled = false;
 
   const search = async ({ dispatch, getState }: ThunkArgs) => {
@@ -89,7 +90,7 @@ export function searchSources(query: string) {
         return;
       }
       await dispatch(loadSourceText(source));
-      await dispatch(searchSource(source.id, query));
+      await dispatch(searchSource(source.id, query, modifiers));
     }
     dispatch(updateSearchStatus(statusType.done));
   };
@@ -101,14 +102,18 @@ export function searchSources(query: string) {
   return search;
 }
 
-export function searchSource(sourceId: string, query: string) {
+export function searchSource(
+  sourceId: string,
+  query: string,
+  modifiers: SearchModifiers
+) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const source = getSource(getState(), sourceId);
     if (!source) {
       return;
     }
 
-    const matches = await findSourceMatches(source, query);
+    const matches = await findSourceMatches(source, query, modifiers);
     if (!matches.length) {
       return;
     }

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -29,6 +29,7 @@ import AccessibleImage from "./shared/AccessibleImage";
 import type { List } from "immutable";
 import type { ActiveSearchType } from "../reducers/types";
 import type { StatusType } from "../reducers/project-text-search";
+import type { SearchModifiers } from "../types";
 
 import "./ProjectSearch.css";
 
@@ -88,8 +89,13 @@ export class ProjectSearch extends Component<Props, State> {
     this.state = {
       inputValue: this.props.query || "",
       inputFocused: false,
-      focusedItem: null
+      focusedItem: null,
+      regexMatch: false,
+      caseSensitive: false,
+      wholeWord: false
     };
+
+    this.getModifiers = this.getModifiers.bind(this);
   }
 
   componentDidMount() {
@@ -118,8 +124,16 @@ export class ProjectSearch extends Component<Props, State> {
     }
   }
 
-  doSearch(searchTerm: string) {
-    this.props.searchSources(searchTerm);
+  getModifiers = () => {
+    return {
+      caseSensitive: this.state.caseSensitive,
+      regexMatch: this.state.regexMatch,
+      wholeWord: this.state.wholeWord
+    };
+  };
+
+  doSearch(searchTerm: string, modifiers: SearchModifiers) {
+    this.props.searchSources(searchTerm, modifiers);
   }
 
   toggleProjectTextSearch = (key: string, e: KeyboardEvent) => {
@@ -167,7 +181,8 @@ export class ProjectSearch extends Component<Props, State> {
     this.setState({ focusedItem: null });
     const query = sanitizeQuery(this.state.inputValue);
     if (query) {
-      this.doSearch(query);
+      const modifiers = this.getModifiers();
+      this.doSearch(query, modifiers);
     }
   };
 
@@ -305,6 +320,16 @@ export class ProjectSearch extends Component<Props, State> {
         handleClose={
           // TODO - This function doesn't quite match the signature.
           (this.props.closeProjectSearch: any)
+        }
+        handleGetModifiers={this.getModifiers}
+        handleModifierRegexMatch={() =>
+          this.setState({ regexMatch: !this.state.regexMatch })
+        }
+        handleModifierCaseSensitive={() =>
+          this.setState({ caseSensitive: !this.state.caseSensitive })
+        }
+        handleModifierWholeWord={() =>
+          this.setState({ wholeWord: !this.state.wholeWord })
         }
         ref="searchInput"
       />

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -94,8 +94,6 @@ export class ProjectSearch extends Component<Props, State> {
       caseSensitive: false,
       wholeWord: false
     };
-
-    this.getModifiers = this.getModifiers.bind(this);
   }
 
   componentDidMount() {

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -119,3 +119,17 @@
 .search-field.big .close-btn {
   margin-inline-end: 8px;
 }
+
+.search-field .search-nav-buttons .active {
+  background: var(--grey-30);
+}
+
+.search-field .search-nav-buttons .active:hover {
+  background: var(--grey-40);
+}
+.search-nav-buttons span {
+  padding: 5px;
+}
+.search-field .search-nav-buttons .margin-right {
+  margin-right: 2px;
+}

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -120,16 +120,20 @@
   margin-inline-end: 8px;
 }
 
-.search-field .search-nav-buttons .active {
-  background: var(--grey-30);
+.search-field .search-nav-buttons .active > span {
+  background-color: var(--theme-icon-checked-color);
 }
 
-.search-field .search-nav-buttons .active:hover {
-  background: var(--grey-40);
-}
 .search-nav-buttons span {
   padding: 5px;
 }
-.search-field .search-nav-buttons .margin-right {
-  margin-right: 2px;
+
+.search-field .search-nav-buttons .modifier-btn {
+    padding: 2px;
+    margin: 0 2px;
+    border: none;
+    background: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 2px;
 }

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -12,7 +12,7 @@ import AccessibleImage from "./AccessibleImage";
 import classnames from "classnames";
 import "./SearchInput.css";
 
-const arrowBtn = (onClick, type, className, tooltip) => {
+const navBtn = (onClick, type, className, tooltip) => {
   const props = {
     className,
     key: type,
@@ -31,6 +31,12 @@ const arrowBtn = (onClick, type, className, tooltip) => {
 type Props = {
   count: number,
   expanded: boolean,
+  handleGetModifiers?: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
+  handleModifierRegexMatch?: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
+  handleModifierCaseSensitive?: (
+    e: SyntheticMouseEvent<HTMLDivElement>
+  ) => void,
+  handleModifierWholeWord?: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
   handleClose?: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
   handleNext?: (e: SyntheticMouseEvent<HTMLButtonElement>) => void,
   handlePrev?: (e: SyntheticMouseEvent<HTMLButtonElement>) => void,
@@ -74,7 +80,10 @@ class SearchInput extends Component<Props, State> {
 
     this.state = {
       inputFocused: false,
-      history: []
+      history: [],
+      regexMatch: false,
+      caseSensitive: false,
+      wholeWord: false
     };
   }
 
@@ -107,17 +116,56 @@ class SearchInput extends Component<Props, State> {
     return <AccessibleImage className="search" />;
   }
 
+  renderModifierButtons() {
+    const {
+      handleModifierRegexMatch,
+      handleModifierCaseSensitive,
+      handleModifierWholeWord
+    } = this.props;
+    const {
+      regexMatch,
+      caseSensitive,
+      wholeWord
+    } = this.props.handleGetModifiers();
+    const regexMatchActiveClass = regexMatch ? "active" : "";
+    const caseSensitiveActiveClass = caseSensitive ? "active" : "";
+    const wholeWordActiveClass = wholeWord ? "active" : "";
+
+    return [
+      navBtn(
+        handleModifierRegexMatch,
+        "regex-match",
+        classnames("nav-btn", "margin-right", regexMatchActiveClass),
+        "Regex"
+      ),
+
+      navBtn(
+        handleModifierCaseSensitive,
+        "case-match",
+        classnames("nav-btn", "margin-right", caseSensitiveActiveClass),
+        "Case Sensitive"
+      ),
+
+      navBtn(
+        handleModifierWholeWord,
+        "whole-word-match",
+        classnames("nav-btn", "margin-right", wholeWordActiveClass),
+        "Match Whole Word"
+      )
+    ];
+  }
+
   renderArrowButtons() {
     const { handleNext, handlePrev } = this.props;
 
     return [
-      arrowBtn(
+      navBtn(
         handlePrev,
         "arrow-up",
         classnames("nav-btn", "prev"),
         L10N.getFormatStr("editor.searchResults.prevResult")
       ),
-      arrowBtn(
+      navBtn(
         handleNext,
         "arrow-down",
         classnames("nav-btn", "next"),
@@ -207,13 +255,24 @@ class SearchInput extends Component<Props, State> {
   }
 
   renderNav() {
-    const { count, handleNext, handlePrev } = this.props;
-    if ((!handleNext && !handlePrev) || (!count || count == 1)) {
-      return;
+    const { count, handleNext, handlePrev, handleGetModifiers } = this.props;
+
+    let arrowNavigation = [];
+
+    if (handleNext && handlePrev && count != 1) {
+      arrowNavigation = this.renderArrowButtons();
+    }
+
+    if (!handleGetModifiers) {
+      return <div className="search-nav-buttons">{arrowNavigation}</div>;
     }
 
     return (
-      <div className="search-nav-buttons">{this.renderArrowButtons()}</div>
+      <div className="search-nav-buttons">
+        {arrowNavigation}
+        <span>Modifiers:</span>
+        {this.renderModifierButtons()}{" "}
+      </div>
     );
   }
 

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -136,21 +136,21 @@ class SearchInput extends Component<Props, State> {
         handleModifierRegexMatch,
         "regex-match",
         classnames("nav-btn", "margin-right", regexMatchActiveClass),
-        "Regex"
+        L10N.getStr("symbolSearch.searchModifier.regex")
       ),
 
       navBtn(
         handleModifierCaseSensitive,
         "case-match",
         classnames("nav-btn", "margin-right", caseSensitiveActiveClass),
-        "Case Sensitive"
+        L10N.getStr("symbolSearch.searchModifier.caseSensitive")
       ),
 
       navBtn(
         handleModifierWholeWord,
         "whole-word-match",
         classnames("nav-btn", "margin-right", wholeWordActiveClass),
-        "Match Whole Word"
+        L10N.getStr("symbolSearch.searchModifier.wholeWord")
       )
     ];
   }

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -135,21 +135,21 @@ class SearchInput extends Component<Props, State> {
       navBtn(
         handleModifierRegexMatch,
         "regex-match",
-        classnames("nav-btn", "margin-right", regexMatchActiveClass),
+        classnames("nav-btn", "modifier-btn", regexMatchActiveClass),
         L10N.getStr("symbolSearch.searchModifier.regex")
       ),
 
       navBtn(
         handleModifierCaseSensitive,
         "case-match",
-        classnames("nav-btn", "margin-right", caseSensitiveActiveClass),
+        classnames("nav-btn", "modifier-btn", caseSensitiveActiveClass),
         L10N.getStr("symbolSearch.searchModifier.caseSensitive")
       ),
 
       navBtn(
         handleModifierWholeWord,
         "whole-word-match",
-        classnames("nav-btn", "margin-right", wholeWordActiveClass),
+        classnames("nav-btn", "modifier-btn", wholeWordActiveClass),
         L10N.getStr("symbolSearch.searchModifier.wholeWord")
       )
     ];

--- a/src/utils/sources-tree/sortTree.js
+++ b/src/utils/sources-tree/sortTree.js
@@ -18,6 +18,7 @@ export function sortEntireTree(
   tree: TreeDirectory,
   debuggeeUrl: string = ""
 ): TreeDirectory {
+  console.log("Sorting ENtire Tree;");
   if (nodeHasChildren(tree)) {
     const contents = sortTree(tree, debuggeeUrl).map((subtree: any) =>
       sortEntireTree(subtree)

--- a/src/utils/sources-tree/sortTree.js
+++ b/src/utils/sources-tree/sortTree.js
@@ -18,7 +18,6 @@ export function sortEntireTree(
   tree: TreeDirectory,
   debuggeeUrl: string = ""
 ): TreeDirectory {
-  console.log("Sorting ENtire Tree;");
   if (nodeHasChildren(tree)) {
     const contents = sortTree(tree, debuggeeUrl).map((subtree: any) =>
       sortEntireTree(subtree)

--- a/src/workers/search/project-search.js
+++ b/src/workers/search/project-search.js
@@ -8,19 +8,17 @@
 
 import getMatches from "./get-matches";
 
-import type { Source } from "../../types";
+import type { Source, SearchModifiers } from "../../types";
 
-export function findSourceMatches(source: Source, queryText: string): Object[] {
+export function findSourceMatches(
+  source: Source,
+  queryText: string,
+  modifiers: SearchModifiers
+): Object[] {
   const { id, loadedState, text } = source;
   if (loadedState != "loaded" || typeof text != "string" || queryText == "") {
     return [];
   }
-
-  const modifiers = {
-    caseSensitive: false,
-    regexMatch: false,
-    wholeWord: false
-  };
 
   const lines = text.split("\n");
 


### PR DESCRIPTION
Fixes #7967 

### Summary of Changes

* Added Regex, Case Sensitive, Whole word modifiers in search ( Ctrl + shift + F )
* Added styles for active classes on modifier buttons.

### Test Plan

Tests can be done by searching using combination of all modifiers and checking their results.

Example test plan:

- [x] Open test file in browser.
- [x] Press Ctrl + Shift + F for searching.
- [x] In Input box, type the words to test.
- [x] Check/ uncheck the modifiers.
- [x] Verify the expected results.


### Screenshots
![screenshot from 2019-02-26 17-24-15](https://user-images.githubusercontent.com/23359602/53416549-beaa9100-39f9-11e9-83a9-5858b4eb5cd5.png)
---

![screenshot from 2019-02-26 17-24-23](https://user-images.githubusercontent.com/23359602/53416556-c0745480-39f9-11e9-8969-167c072327dd.png)

---

![screenshot from 2019-02-26 17-24-44](https://user-images.githubusercontent.com/23359602/53416563-c4a07200-39f9-11e9-8ce4-56fb5e8b1ccb.png)
