### PR TITLE
Fix 7799 - Restore pretty print shim to tab context menu

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -26,7 +26,6 @@ import {
   isPretty,
   shouldBlackbox
 } from "../../utils/source";
-import { shouldShowPrettyPrint } from "../../utils/editor";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getTabMenuItems } from "../../utils/tabs";
 
@@ -135,10 +134,7 @@ class Tab extends PureComponent<Props> {
           disabled: !selectedSource.url,
           click: () => showSource(tab)
         }
-      }
-    ];
-
-    items.push(
+      },
       {
         item: {
           ...tabMenuItems.toggleBlackBox,
@@ -153,10 +149,10 @@ class Tab extends PureComponent<Props> {
         item: {
           ...tabMenuItems.prettyPrint,
           click: () => togglePrettyPrint(tab),
-          disabled: !shouldShowPrettyPrint(source)
+          disabled: isPretty(sourceTab)
         }
       }
-    );
+    ];
 
     showMenu(e, buildMenu(items));
   }


### PR DESCRIPTION
Fixes #7799 

Essentially reverts https://github.com/firefox-devtools/debugger/commit/04ee6a4b2d805ba5ba53eb48f167897182366099