### PR TITLE
Added Firefox Nightly CLI launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn start
 # Go to http://localhost:8000
 ```
 
-If you are having problems with setting breakpoints in the debugger, launch [Firefox Nightly](https://github.com/firefox-devtools/debugger/blob/master/docs/getting-setup.md#starting-firefox-nightly) instead of clicking on `Launch Firefox`.
+If you are having problems with setting breakpoints in the debugger, launch [Firefox Nightly][firefox-nightly] instead of clicking on `Launch Firefox`.
 
 #### Next Steps
 
@@ -131,3 +131,4 @@ Say hello in [Slack][slack] or in the [#devtools-html][irc-devtools-html] channe
 [linting]: ./docs/local-development.md#linting
 [google-docs]: https://docs.google.com/document/d/146p7Y8Ues_AKjj4ReWCk6InOPWe3C3Koy6EQ1qnYKNM/edit
 [cl]: ./docs/issues.md#claiming-issues
+[firefox-nightly]: ./docs/getting-setup.md#starting-firefox-nightly

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ yarn start
 # Go to http://localhost:8000
 ```
 
+If you are having problems with setting breakpoints in the debugger, launch [Firefox Nightly](https://github.com/firefox-devtools/debugger/blob/master/docs/getting-setup.md#starting-firefox-nightly) instead of clicking on `Launch Firefox`.
+
 #### Next Steps
 
 - [`/claim`][cl] an [available] issue. If you get stuck, we'd be happy to [help].

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -119,6 +119,33 @@ If you are not seeing any tabs when you connect, it is possible that switching f
 > NOTE: if you are curious about how the debugger server starts listening on a port
 > this function is useful: [devtools-startup.js](https://searchfox.org/mozilla-central/source/devtools/startup/devtools-startup.js#789-854)
 
+### Starting Firefox Nightly
+
+You can open and debug a Firefox Nightly tab with the command-line interface (CLI).
+
+>Steps 4-6 is for the Firefox Nightly configuration and **only need to be done once**:
+
+1) Update/rebase your local Debugger repository, and download [Firefox Nightly](https://www.mozilla.org/en-CA/firefox/channel/desktop/)
+2) Run `yarn start` and open `localhost:8000` on your browser
+3) In a separate terminal tab, open Nightly with:
+```shell
+# For Mac Users
+/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox --start-debugger-server 6080
+
+# For Windows Users
+C:\Program Files\Firefox Nightly\firefox.exe -start-debugger-server 6080
+```
+4) Go to `about:config` in the URL bar
+5) Toggle the following preferences to their corresponding values:
+
+|Preference Name|Value|
+|--|--|
+|`devtools.debugger.remote-enabled`|`true`|
+|`devtools.chrome.enabled`|`true`|
+|`devtools.debugger.prompt-connection`|`false`|
+6) Close, and then open Firefox Nightly (like in step 3)
+7) Give it a few seconds for the Nightly tab to show up in launchpad
+
 ### Starting Chrome
 
 There are two ways to run Chrome for the purposes of remote debugging with the debugger:


### PR DESCRIPTION
The current Firefox launcher in launchpad launches the stable Firefox release, where setting breakpoints is broken. This PR adds instructions in the documentation for contributors to launch Firefox Nightly instead with the CLI.
- Added instructions for launching Firefox Nightly with CLI in `getting-setup.md`
- Added a note after the Quick Setup section in the project's `README.md` to launch Firefox Nightly
