### PR TITLE
Fix 8026 - Prevent breakpoint label from triggering checkbox focus

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -149,6 +149,7 @@ class Breakpoint extends PureComponent<Props> {
     const { breakpoint } = this.props;
     const text = this.getBreakpointText();
     const editor = getEditor();
+    const labelId = `${breakpoint.id}-label`;
     return (
       <div
         className={classnames({
@@ -169,15 +170,16 @@ class Breakpoint extends PureComponent<Props> {
           checked={!breakpoint.disabled}
           onChange={this.handleBreakpointCheckbox}
           onClick={ev => ev.stopPropagation()}
+          aria-labelledby={labelId}
         />
-        <label
-          htmlFor={breakpoint.id}
+        <span
+          id={labelId}
           className="breakpoint-label cm-s-mozilla devtools-monospace"
           onClick={this.selectBreakpoint}
           title={text}
         >
           <span dangerouslySetInnerHTML={this.highlightText(text, editor)} />
-        </label>
+        </span>
         <div className="breakpoint-line-close">
           <div className="breakpoint-line devtools-monospace">
             {this.getBreakpointLocation()}

--- a/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
@@ -67,7 +67,8 @@ function makeBreakpoint(overrides = {}) {
     generatedLocation,
     disabled: false,
     options: {},
-    ...overrides
+    ...overrides,
+    id: 1
   };
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -8,16 +8,17 @@ exports[`Breakpoint disabled 1`] = `
   onDoubleClick={[Function]}
 >
   <input
-    aria-labelledby="undefined-label"
+    aria-labelledby="1-label"
     checked={false}
     className="breakpoint-checkbox"
+    id={1}
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
-    id="undefined-label"
+    id="1-label"
     onClick={[Function]}
   >
     <span
@@ -52,16 +53,17 @@ exports[`Breakpoint paused at a different 1`] = `
   onDoubleClick={[Function]}
 >
   <input
-    aria-labelledby="undefined-label"
+    aria-labelledby="1-label"
     checked={true}
     className="breakpoint-checkbox"
+    id={1}
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
-    id="undefined-label"
+    id="1-label"
     onClick={[Function]}
   >
     <span
@@ -96,16 +98,17 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
   onDoubleClick={[Function]}
 >
   <input
-    aria-labelledby="undefined-label"
+    aria-labelledby="1-label"
     checked={true}
     className="breakpoint-checkbox"
+    id={1}
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
-    id="undefined-label"
+    id="1-label"
     onClick={[Function]}
   >
     <span
@@ -140,16 +143,17 @@ exports[`Breakpoint paused at an original location 1`] = `
   onDoubleClick={[Function]}
 >
   <input
-    aria-labelledby="undefined-label"
+    aria-labelledby="1-label"
     checked={true}
     className="breakpoint-checkbox"
+    id={1}
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
-    id="undefined-label"
+    id="1-label"
     onClick={[Function]}
   >
     <span
@@ -184,16 +188,17 @@ exports[`Breakpoint simple 1`] = `
   onDoubleClick={[Function]}
 >
   <input
-    aria-labelledby="undefined-label"
+    aria-labelledby="1-label"
     checked={true}
     className="breakpoint-checkbox"
+    id={1}
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
-    id="undefined-label"
+    id="1-label"
     onClick={[Function]}
   >
     <span

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -8,14 +8,16 @@ exports[`Breakpoint disabled 1`] = `
   onDoubleClick={[Function]}
 >
   <input
+    aria-labelledby="undefined-label"
     checked={false}
     className="breakpoint-checkbox"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
-  <label
+  <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
+    id="undefined-label"
     onClick={[Function]}
   >
     <span
@@ -25,7 +27,7 @@ exports[`Breakpoint disabled 1`] = `
         }
       }
     />
-  </label>
+  </span>
   <div
     className="breakpoint-line-close"
   >
@@ -50,14 +52,16 @@ exports[`Breakpoint paused at a different 1`] = `
   onDoubleClick={[Function]}
 >
   <input
+    aria-labelledby="undefined-label"
     checked={true}
     className="breakpoint-checkbox"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
-  <label
+  <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
+    id="undefined-label"
     onClick={[Function]}
   >
     <span
@@ -67,7 +71,7 @@ exports[`Breakpoint paused at a different 1`] = `
         }
       }
     />
-  </label>
+  </span>
   <div
     className="breakpoint-line-close"
   >
@@ -92,14 +96,16 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
   onDoubleClick={[Function]}
 >
   <input
+    aria-labelledby="undefined-label"
     checked={true}
     className="breakpoint-checkbox"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
-  <label
+  <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
+    id="undefined-label"
     onClick={[Function]}
   >
     <span
@@ -109,7 +115,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
         }
       }
     />
-  </label>
+  </span>
   <div
     className="breakpoint-line-close"
   >
@@ -134,14 +140,16 @@ exports[`Breakpoint paused at an original location 1`] = `
   onDoubleClick={[Function]}
 >
   <input
+    aria-labelledby="undefined-label"
     checked={true}
     className="breakpoint-checkbox"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
-  <label
+  <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
+    id="undefined-label"
     onClick={[Function]}
   >
     <span
@@ -151,7 +159,7 @@ exports[`Breakpoint paused at an original location 1`] = `
         }
       }
     />
-  </label>
+  </span>
   <div
     className="breakpoint-line-close"
   >
@@ -176,14 +184,16 @@ exports[`Breakpoint simple 1`] = `
   onDoubleClick={[Function]}
 >
   <input
+    aria-labelledby="undefined-label"
     checked={true}
     className="breakpoint-checkbox"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
-  <label
+  <span
     className="breakpoint-label cm-s-mozilla devtools-monospace"
+    id="undefined-label"
     onClick={[Function]}
   >
     <span
@@ -193,7 +203,7 @@ exports[`Breakpoint simple 1`] = `
         }
       }
     />
-  </label>
+  </span>
   <div
     className="breakpoint-line-close"
   >


### PR DESCRIPTION
Fixes #8026 

### Summary of Changes

* Replace breakpoint's `label` tag for a `span`, including `aria-labelledby` to the breakpoint's checkbox
* Update breakpoint test snapshot

### Test Plan

Being quite straightforward, I followed @fvsch's advice in the issue's comments but think I bumped into #6965. If anyone can confirm that the change solves the issue I would appreciate it. Thanks!
