### PR TITLE
Unify array creation style in SecondaryPanes getStartItems and getEndItems

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -300,7 +300,7 @@ class SecondaryPanes extends Component<Props, State> {
     };
   }
 
-  getEventListenersItem() {
+  getEventListenersItem(): AccordionPaneItem {
     return {
       header: L10N.getStr("eventListenersHeader"),
       className: "event-listeners-pane",
@@ -313,12 +313,11 @@ class SecondaryPanes extends Component<Props, State> {
     };
   }
 
-  getStartItems() {
-    const { workers } = this.props;
+  getStartItems(): AccordionPaneItem[] {
+    const items: AccordionPaneItem[] = [];
 
-    const items: Array<AccordionPaneItem> = [];
     if (this.props.horizontal) {
-      if (features.workers && workers.length > 0) {
+      if (features.workers && this.props.workers.length > 0) {
         items.push(this.getWorkersItem());
       }
 
@@ -329,7 +328,6 @@ class SecondaryPanes extends Component<Props, State> {
 
     if (this.props.hasFrames) {
       items.push(this.getCallStackItem());
-
       if (this.props.horizontal) {
         items.push(this.getScopeItem());
       }
@@ -343,37 +341,34 @@ class SecondaryPanes extends Component<Props, State> {
       items.push(this.getEventListenersItem());
     }
 
-    return items.filter(item => item);
+    return items;
   }
 
-  renderHorizontalLayout() {
-    return <Accordion items={this.getItems()} />;
-  }
-
-  getEndItems() {
-    const { workers } = this.props;
-
-    let items: Array<AccordionPaneItem> = [];
-
+  getEndItems(): AccordionPaneItem[] {
     if (this.props.horizontal) {
       return [];
     }
 
-    if (features.workers && workers.length > 0) {
+    const items: AccordionPaneItem[] = [];
+    if (features.workers && this.props.workers.length > 0) {
       items.push(this.getWorkersItem());
     }
 
     items.push(this.getWatchItem());
 
     if (this.props.hasFrames) {
-      items = [...items, this.getScopeItem()];
+      items.push(this.getScopeItem());
     }
 
     return items;
   }
 
-  getItems() {
+  getItems(): AccordionPaneItem[] {
     return [...this.getStartItems(), ...this.getEndItems()];
+  }
+
+  renderHorizontalLayout() {
+    return <Accordion items={this.getItems()} />;
   }
 
   renderVerticalLayout() {


### PR DESCRIPTION
So I was just chilling in `SecondaryPanes/index.js` and noticed that a bit of code was using `items = [ ...items, newItem ]` to basically do an `items.push(newItem)` (unlike all of the surrounding code) and thought I would harmonize that.

I also moved `renderHorizontalLayout` just before `renderVerticalLayout` to organize things a bit. Since it's a very short method it's not too big of a change.

So, nothing major, and if you don't like it you can also close the PR. :)