### PR TITLE
Revert "Update setPreview to properly display falsy values in preview tooltip"

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -104,6 +104,10 @@ export function setPreview(
           thread: selectedFrame.thread
         });
 
+        if (!result) {
+          return;
+        }
+
         return {
           expression,
           result,


### PR DESCRIPTION
Reverts firefox-devtools/debugger#8027

While reviewing the latest release (https://phabricator.services.mozilla.com/D21608), the following caused the debugger to go blank:

1.  Go to https://davidwalsh.name
2.  Add breakpoint to line 1 of main.js
3.  Refresh browser, breakpoint will hit
4.  Hover over "hash"
5.  Debugger bricks

The following error is shown:

```
console.error: (new TypeError("value is null", "resource://devtools/client/debugger/new/src/components/Editor/Preview/index.js", 149))
JavaScript error: resource://devtools/client/debugger/new/src/components/Editor/Preview/index.js, line 149: TypeError: value is null
```

After removing this commit, the debugger no longer bricks.

We need to further investigate why but in the mean time we should revert this commit.

cc @ravefalcon92 