### PR TITLE
Align watch expressions and scopes pane

### DIFF
--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -25,7 +25,6 @@
 
 .tree .tree-node {
   display: flex;
-  padding-top: 1px;
 }
 
 .tree .tree-node:not(.focused):hover {

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -34,9 +34,15 @@
 .tree-indent {
   display: inline-block;
   width: 12px;
-  margin-inline-start: 5px;
+  margin-inline-start: 3px;
   border-inline-start: 1px solid #a2d1ff;
   flex-shrink: 0;
+}
+
+.debugger .tree-indent {
+  width: 16px;
+  margin-inline-start: 0px;
+  border-inline-start: 0;
 }
 
 /* For non expandable root nodes, we don't have .tree-indent elements, so we declare

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -25,6 +25,7 @@
 
 .tree .tree-node {
   display: flex;
+  padding-top: 1px;
 }
 
 .tree .tree-node:not(.focused):hover {
@@ -37,11 +38,6 @@
   margin-inline-start: 5px;
   border-inline-start: 1px solid #a2d1ff;
   flex-shrink: 0;
-}
-
-/* Align with expandables siblings (where we have the arrow) */
-.tree-node[data-expandable="false"] .tree-indent:last-of-type {
-  margin-inline-end: 15px;
 }
 
 /* For non expandable root nodes, we don't have .tree-indent elements, so we declare
@@ -63,7 +59,7 @@
   border: 0;
   padding: 0;
   margin-inline-start: 1px;
-  margin-inline-end: 4px;
+  margin-inline-end: 6px;
   transform-origin: center center;
   transition: transform 125ms var(--animation-curve);
   background-color: var(--theme-icon-dimmed-color);

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -57,8 +57,7 @@
   height: 10px;
   border: 0;
   padding: 0;
-  margin-inline-start: 1px;
-  margin-inline-end: 6px;
+  margin-inline-end: 4px;
   transform-origin: center center;
   transition: transform 125ms var(--animation-curve);
   background-color: var(--theme-icon-dimmed-color);

--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
@@ -43,7 +43,7 @@
 .object-inspector .tree-node .arrow {
   display: inline-block;
   vertical-align: middle;
-  margin-inline-start: -1px
+  margin-inline-start: -1px;
 }
 
 /* Focused styles */

--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
@@ -28,8 +28,12 @@
 }
 
 .tree.object-inspector .block .object-label::before {
-  content: "☲ ";
-  font-size: 1.1em;
+  content: "☲";
+  font-size: 1em;
+  display: inline-block;
+  margin-top: -1px;
+  vertical-align: text-top;
+  padding-inline-start: 3px;
 }
 
 .object-inspector .object-delimiter {

--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
@@ -29,11 +29,10 @@
 
 .tree.object-inspector .block .object-label::before {
   content: "☲";
-  font-size: 1em;
-  display: inline-block;
-  margin-top: -1px;
-  vertical-align: text-top;
-  padding-inline-start: 3px;
+  font-size: 1.1em;
+  display: inline;
+  padding-inline-end: 2px;
+  line-height: 14px;
 }
 
 .object-inspector .object-delimiter {

--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
@@ -34,11 +34,13 @@
 
 .object-inspector .object-delimiter {
   color: var(--theme-comment);
+  white-space: pre-wrap;
 }
 
 .object-inspector .tree-node .arrow {
   display: inline-block;
   vertical-align: middle;
+  margin-inline-start: -1px
 }
 
 /* Focused styles */

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -118,10 +118,6 @@
   height: 100%;
 }
 
-.tree-indent {
-  border-inline-start: 0 none;
-}
-
 .source-outline-tabs {
   font-size: 12px;
   width: 100%;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -97,11 +97,11 @@
 }
 
 :root.theme-light .expression-container:hover {
-  background-color: var(--theme-selection-background-hover);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 :root.theme-dark .expression-container:hover {
-  background-color: var(--theme-selection-background-hover);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .tree .tree-node:not(.focused):hover {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -88,6 +88,8 @@
 
 .expression-container .tree .tree-node[aria-level="1"] {
   padding-top: 0px;
+  /* keep line-height at 14px to prevent row from shifting upon expansion */
+  line-height: 14px;
 }
 
 .expression-container .tree-node[aria-level="1"] .object-label {
@@ -144,7 +146,7 @@
 .expression-content .tree {
   overflow: hidden;
   flex-grow: 1;
-  line-height: 14px;
+  line-height: 15px;
 }
 
 /* to prevent the row from shifting vertically upon expanding the node */

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -11,8 +11,11 @@
   margin: 0;
   border: 1px;
   background-color: var(--theme-sidebar-background);
-  font-size: 12px;
-  padding: 0.5em 1.6em;
+  line-height: 16px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-inline-start: 19px;
+  padding-inline-end: 12px;
   color: var(--theme-body-color);
   outline: 0;
 }
@@ -66,19 +69,31 @@
 
 .expression-container {
   border: 1px;
-  padding: 0.6em 1em 0.6em 0.5em;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-inline-start: 20px;
+  padding-inline-end: 12px;
   width: 100%;
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   display: block;
   position: relative;
   overflow: hidden;
-  min-height: var(--breakpoint-expression-height);
 }
 
 .expression-container > .tree {
   width: 100%;
   overflow: hidden;
+}
+
+.expression-container .tree .tree-node[aria-level="1"] {
+  padding-top: 0px;
+}
+
+.expression-container .tree-node[aria-level="1"] .object-label {
+  font-family: var(--monospace-font-family);
+  line-height: 13px;
+  padding-top: 1px;
 }
 
 :root.theme-light .expression-container:hover {
@@ -104,29 +119,41 @@
   top: calc(50% - 8px);
 }
 
-[dir="ltr"] .expression-container__close-btn {
-  right: 0;
+.expression-content .object-node {
+  padding-inline-start: 0px;
 }
 
-[dir="rtl"] .expression-container__close-btn {
-  left: 0;
+.expressions-list .tree.object-inspector .node.object-node {
+  display: flex;
+  align-items: center;
+}
+
+.expression-container__close-btn {
+  max-height: 16px;
+  padding-inline-start: 4px;
+  align-self: flex-start;
 }
 
 .expression-content {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
   position: relative;
 }
 
 .expression-content .tree {
-  overflow-x: hidden;
-  max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
+  overflow: hidden;
+  flex-grow: 1;
+  line-height: 14px;
 }
 
-.expression-content .tree-node {
-  overflow-x: hidden;
+/* to prevent the row from shifting vertically upon expanding the node */
+.expression-content .tree-node[aria-expanded="true"][aria-level="1"] {
+  margin-top: 1px;
 }
 
 .expression-content .tree-node[data-expandable="false"][aria-level="1"] {
-  padding-inline-start: 10px;
+  padding-inline-start: 0px;
 }
 
 .input-expression:not(:placeholder-shown) {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -69,7 +69,6 @@
 }
 
 .expression-container {
-  border: 1px;
   padding-top: 2px;
   padding-bottom: 2px;
   padding-inline-start: 20px;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -115,8 +115,9 @@
 }
 
 .expression-container:hover .expression-container__close-btn,
+.expression-container:focus-within .expression-container__close-btn,
 .expression-container__close-btn:focus-within {
-  top: calc(50% - 8px);
+  top: -1px;
 }
 
 .expression-content .object-node {
@@ -131,7 +132,14 @@
 .expression-container__close-btn {
   max-height: 16px;
   padding-inline-start: 4px;
-  align-self: flex-start;
+}
+
+[dir="ltr"] .expression-container__close-btn {
+  right: 0;
+}
+
+[dir="rtl"] .expression-container__close-btn {
+  left: 0;
 }
 
 .expression-content {
@@ -145,11 +153,6 @@
   overflow: hidden;
   flex-grow: 1;
   line-height: 15px;
-}
-
-/* to prevent the row from shifting vertically upon expanding the node */
-.expression-content .tree-node[aria-expanded="true"][aria-level="1"] {
-  margin-top: 1px;
 }
 
 .expression-content .tree-node[data-expandable="false"][aria-level="1"] {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -9,6 +9,7 @@
 .input-expression {
   width: 100%;
   margin: 0;
+  font-size: inherit;
   border: 1px;
   background-color: var(--theme-sidebar-background);
   line-height: 16px;
@@ -94,8 +95,6 @@
 
 .expression-container .tree-node[aria-level="1"] .object-label {
   font-family: var(--monospace-font-family);
-  line-height: 13px;
-  padding-top: 1px;
 }
 
 :root.theme-light .expression-container:hover {

--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -26,7 +26,7 @@
 }
 
 .object-node {
-  padding-left: 4px;
+  padding-inline-start: 20px;
 }
 
 html[dir="rtl"] .object-node {
@@ -52,7 +52,8 @@ html[dir="rtl"] .object-node {
   white-space: nowrap;
 }
 
-.scopes-pane {
+.scopes-list {
+  padding: 4px 0px;
   overflow: auto;
 }
 
@@ -76,4 +77,14 @@ html[dir="rtl"] .object-node {
 
 .scopes-list .scope-type-toggle button:hover {
   background: transparent;
+}
+
+.scopes-list .tree.object-inspector .node.object-node {
+  display: flex;
+  align-items: center;
+}
+
+.scopes-list .tree {
+  /* overflow: hidden; */
+  line-height: 14px;
 }

--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -85,6 +85,5 @@ html[dir="rtl"] .object-node {
 }
 
 .scopes-list .tree {
-  /* overflow: hidden; */
-  line-height: 14px;
+  line-height: 15px;
 }


### PR DESCRIPTION
These are the Watch Expressions and Scopes changes from the [UX alignment issue](https://github.com/firefox-devtools/ux/issues/45) adapted to the [Event Listeners](#7937). I put them together in the same PR since they split the Object Rep styles between the two of them.

* Changed rows to 20px height
* Changed watched expression font to monospace
* Changed monospace font size to 11px
* Changed pane content indent to 20px
* Changed tree indents to 14px to match arrow spacing
* Removed [inset-inline-end](#8017) selectors 

<img width="825" alt="screen shot 2019-03-04 at 11 07 17 am" src="https://user-images.githubusercontent.com/15959269/53745792-b4f7b200-3e6d-11e9-93fa-cf978ce95ef5.png">

@fvsch @mcroud Thoughts?