### PR TITLE
Update index.js

### DIFF
--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -42,8 +42,7 @@ function inPopup(e) {
 
   const pop =
     relatedTarget.closest(".tooltip") ||
-    relatedTarget.closest(".popover") ||
-    relatedTarget.classList.contains("debug-expression");
+    relatedTarget.closest(".popover");
 
   return pop;
 }

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -41,8 +41,7 @@ function inPopup(e) {
   }
 
   const pop =
-    relatedTarget.closest(".tooltip") ||
-    relatedTarget.closest(".popover");
+    relatedTarget.closest(".tooltip") || relatedTarget.closest(".popover");
 
   return pop;
 }


### PR DESCRIPTION
Fixes #7952 

### Summary of Changes

* Deleted the part of the conditional that looks for the class name "debug-expression." I looked at Git Blame to find out why this line was added. Since "debug-expression" has no relationship to the highlighted token but instead is the class name added to elements along the entire debug line, there is no reason to include a check for it.

### Test Plan
- [x] Mousing out of a token and onto the debug line does end the preview.
- [x] Mousing out of a token but not onto the debug line does end the preview (previous behavior is not broken).
- [x] Mousing into a token from the debug line starts the preview.
- [x] Mousing out of a token but into a tool tip or popup does not end the preview (previous behavior is not broken).

Thanks @darkwing for confirming that this solution works. 