### PR TITLE
Fix #7956 - Show falsy values in preview

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -104,9 +104,10 @@ export function setPreview(
           thread: selectedFrame.thread
         });
 
-        // This specific case occurs for a token that follows an errored evaluation
+        // Error case occurs for a token that follows an errored evaluation
         // https://github.com/firefox-devtools/debugger/pull/8056
-        // Accommodating for this case allows us to show preview for falsy values
+        // Accommodating for null allows us to show preview for falsy values
+        // line "", false, null, Nan, and more
         if (result === null) {
           return;
         }

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -104,7 +104,10 @@ export function setPreview(
           thread: selectedFrame.thread
         });
 
-        if (!result) {
+        // This specific case occurs for a token that follows an errored evaluation
+        // https://github.com/firefox-devtools/debugger/pull/8056
+        // Accommodating for this case allows us to show preview for falsy values
+        if (result === null) {
           return;
         }
 

--- a/test/mochitest/browser_dbg-preview.js
+++ b/test/mochitest/browser_dbg-preview.js
@@ -1,5 +1,6 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 async function previews(dbg, fnName, previews) {
   const invokeResult = invokeInTab(fnName);
@@ -18,8 +19,8 @@ add_task(async function() {
   await selectSource(dbg, "preview.js");
 
   await previews(dbg, "empties", [
-    // { line: 2, column: 9, expression: "a", result: '""' },
-    // { line: 3, column: 9, expression: "b", result: "false" },
+    { line: 2, column: 9, expression: "a", result: '""' },
+    { line: 3, column: 9, expression: "b", result: "false" },
     { line: 4, column: 9, expression: "c", result: "undefined" },
     { line: 5, column: 9, expression: "d", result: "null" }
   ]);


### PR DESCRIPTION
Fixes #7956

Good manual testing:  
 - Basic: http://breezy-join.glitch.me/
 - Previously found brick case:  https://github.com/firefox-devtools/debugger/pull/8056#issue-257591385

I also updated the test that had these values commented out.