### PR TITLE
#7993 Fix callstack frame-group icon and avoid global selectors

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -81,13 +81,13 @@
   color: white;
 }
 
-.show-more-container {
+.frames .show-more-container {
   display: flex;
   min-height: 24px;
   padding: 4px 0;
 }
 
-.show-more {
+.frames .show-more {
   text-align: center;
   padding: 8px 0px;
   margin: 7px 10px 7px 7px;
@@ -98,25 +98,20 @@
   color: inherit;
 }
 
-.show-more:hover {
+.frames .show-more:hover {
   background-color: var(--theme-toolbar-background-hover);
 }
 
-.annotation-logo {
-  mask-size: 100%;
-  display: inline-block;
-  width: 12px;
-}
-
-:root.theme-dark .annotation-logo:not(.angular) svg path {
-  fill: var(--theme-highlight-blue);
+.frames .img.annotation-logo {
+  margin-inline-end: 4px;
+  background-color: currentColor;
 }
 
 /* Some elements are added to the DOM only to be printed into the clipboard
    when the user copy some elements. We don't want those elements to mess with
    the layout so we put them outside of the screen
 */
-.clipboard-only {
+.frames .clipboard-only {
   position: absolute;
   left: -9999px;
 }

--- a/src/components/SecondaryPanes/Frames/Group.css
+++ b/src/components/SecondaryPanes/Frames/Group.css
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.frames [role="list"] .frames-group .group,
-.frames [role="list"] .frames-group .group .location {
+.frames-group .group,
+.frames-group .group .location {
   font-weight: 500;
   cursor: default;
   /*
@@ -14,24 +14,25 @@
   direction: ltr;
 }
 
-.frames [role="list"] .frames-group.expanded .group,
-.frames [role="list"] .frames-group.expanded .group .location {
+.frames-group.expanded .group,
+.frames-group.expanded .group .location {
   color: var(--theme-highlight-blue);
 }
 
-.frames [role="list"] .frames-group .frames-list [role="listitem"] {
-  padding-left: 30px;
+.frames-group .frames-list [role="listitem"] {
+  padding-inline-start: 30px;
 }
 
-.frames [role="list"] .frames-group .frames-list {
+.frames-group .frames-list {
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
-.frames [role="list"] .frames-group.expanded .badge {
+.frames-group.expanded .badge {
   color: var(--theme-highlight-blue);
 }
 
-.group-description-name {
-  padding-left: 5px;
+.frames-group .img.arrow {
+  margin-inline-start: -1px;
+  margin-inline-end: 4px;
 }


### PR DESCRIPTION
- Fixes #7993
- Fixes global selectors in SecondaryPanes/Frames (#7905)

Result looks like this:

### React

Monochrome icons use the label's text color. We had some outdated targetting SVG paths that was doing that, so I replicated the effect:

<img alt="react group 1" width="300" src="https://user-images.githubusercontent.com/243601/53826497-02147a80-3f79-11e9-891f-e2872ebf4ab8.png">

<img alt="react group 2" width="288" src="https://user-images.githubusercontent.com/243601/53826623-4dc72400-3f79-11e9-85cd-78ef44e54350.png">

### Webpack

Multicolor icons don't change depending on the normal/expanded state:

<img alt="webpack group 1" width="300" src="https://user-images.githubusercontent.com/243601/53826289-97633f00-3f78-11e9-8dde-25cb3f62cfe2.png">

<img alt="webpack group 2" width="288" src="https://user-images.githubusercontent.com/243601/53826318-a518c480-3f78-11e9-8164-1242d0f38c28.png">


