### PR TITLE
Fix 7674 - Ensure breakpoint text is always highlighted

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -22,6 +22,7 @@ import {
 import { getSelectedLocation } from "../../../utils/source-maps";
 import { features } from "../../../utils/prefs";
 import { getEditor } from "../../../utils/editor";
+import { createEditor } from "../../../utils/editor/create-editor";
 
 import type {
   Breakpoint as BreakpointType,
@@ -133,12 +134,18 @@ class Breakpoint extends PureComponent<Props> {
 
   highlightText = memoize(
     (text = "", editor) => {
+      let fakeEditor = null;
       if (!editor.CodeMirror) {
-        return { __html: text };
+        fakeEditor = editor = createEditor();
+        fakeEditor.appendToLocalElement(document.createElement("div"));
       }
 
       const node = document.createElement("div");
       editor.CodeMirror.runMode(text, "application/javascript", node);
+
+      if (fakeEditor) {
+        fakeEditor.destroy();
+      }
       return { __html: node.innerHTML };
     },
     (text, editor) => `${text} - ${editor.CodeMirror ? "editor" : ""}`


### PR DESCRIPTION
Fixes #7674 

Breakpoints aren't highlighted if the debugger is opened without a tab open.  To reproduce, you can open the debugger, add a breakpoint, close the source, close devtools, and then reopen the debugger.

This is mostly a POC to get feedback.  There isn't really a pretty way to do this.