### PR TITLE
Fix #8017 - Work around unsupported inset-inline-start|end in Chrome

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -180,10 +180,17 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint .close-btn {
-  inset-inline-end: 15px;
-  inset-inline-start: auto;
   position: absolute;
-  top: -100px; /*For hiding button outside of row until hovered or focused*/
+  /* hide button outside of row until hovered or focused */
+  top: -100px;
+}
+
+[dir="ltr"] .breakpoint .close-btn {
+  right: 12px;
+}
+
+[dir="rtl"] .breakpoint .close-btn {
+  left: 12px;
 }
 
 .breakpoint:hover .close-btn,

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -94,8 +94,15 @@
 
 .expression-container__close-btn {
   position: absolute;
-  inset-inline-end: 0px;
-  top: 1px;
+  top: calc(50% - 8px);
+}
+
+[dir="ltr"] .expression-container__close-btn {
+  right: 0;
+}
+
+[dir="rtl"] .expression-container__close-btn {
+  left: 0;
 }
 
 .expression-content {

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -109,8 +109,14 @@
 }
 
 .xhr-container__close-btn {
-  inset-inline-end: 12px;
-  inset-inline-start: auto;
   position: absolute;
-  top: 8px;
+  top: calc(50% - 8px);
+}
+
+[dir="ltr"] .xhr-container__close-btn {
+  right: 12px;
+}
+
+[dir="rtl"] .xhr-container__close-btn {
+  left: 12px;
 }

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -32,18 +32,27 @@
 }
 
 .search-field .img.search {
+  --icon-mask-size: 12px;
+  --icon-inset-inline-start: 6px;
   position: absolute;
   z-index: 1;
-  inset-inline-start: 6px;
   top: calc(50% - 8px);
-  mask-size: 12px;
+  mask-size: var(--icon-mask-size);
   background-color: var(--theme-icon-dimmed-color);
   pointer-events: none;
 }
 
 .search-field.big .img.search {
-  inset-inline-start: 12px;
-  mask-size: 16px;
+  --icon-mask-size: 16px;
+  --icon-inset-inline-start: 12px;
+}
+
+[dir="ltr"] .search-field .img.search {
+  left: var(--icon-inset-inline-start);
+}
+
+[dir="rtl"] .search-field .img.search {
+  right: var(--icon-inset-inline-start);
 }
 
 .search-field .img.loader {


### PR DESCRIPTION
Fixes #8017

I'm setting left:x and right:x properties manually for the `ltr` and `rtl` directions.
Absolute positioning is rare in Debugger, so it's not a lot of work.

I've left two uses of `inset-inline-start|end` around:

- `WelcomeBox.css`: that usage should be removed in #8039
- `Dropdown.css`: addressed in #8081
