### PR TITLE
Use O(N) algorithm in getUniqueIdentifiers.

### DIFF
--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -17,7 +17,7 @@ import {
   getComments,
   getSpecifiers,
   getCode,
-  nodeHasSameLocation,
+  nodeLocationKey,
   getFunctionParameterNames
 } from "./utils/helpers";
 
@@ -87,8 +87,11 @@ let symbolDeclarations: Map<string, SymbolDeclarations> = new Map();
 
 function getUniqueIdentifiers(identifiers) {
   const newIdentifiers = [];
+  const locationKeys = new Set();
   for (const newId of identifiers) {
-    if (!newIdentifiers.find(id => nodeHasSameLocation(id, newId))) {
+    const key = nodeLocationKey(newId);
+    if (!locationKeys.has(key)) {
+      locationKeys.add(key);
       newIdentifiers.push(newId);
     }
   }

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -7,7 +7,6 @@
 import * as t from "@babel/types";
 import type { Node } from "@babel/types";
 import type { SimplePath } from "./simple-path";
-import type { AstLocation } from "../types";
 import generate from "@babel/generator";
 
 export function isFunction(node: Node) {
@@ -178,17 +177,9 @@ export function isTopLevel(ancestors: Node[]) {
   return ancestors.filter(ancestor => ancestor.key == "body").length == 1;
 }
 
-export function nodeHasSameLocation(a: Node, b: Node) {
-  return sameLocation(a.location, b.location);
-}
-
-export function sameLocation(a: AstLocation, b: AstLocation) {
-  return (
-    a.start.line == b.start.line &&
-    a.start.column == b.start.column &&
-    a.end.line == b.end.line &&
-    a.end.column == b.end.column
-  );
+export function nodeLocationKey(a: Node) {
+  const { start, end } = a.location;
+  return `${start.line}:${start.column}:${end.line}:${end.column}`;
 }
 
 export function getFunctionParameterNames(path: SimplePath): string[] {


### PR DESCRIPTION
Fixes #8057

### Summary of Changes

* Make getUniqueIdentifiers() O(N) instead of O(N^2), fixing performance of this function on large workloads.

### Test Plan

Tested on #8057 testcase