### PR TITLE
Fix #8084 - Vue.js icon missing in Frames

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -107,6 +107,13 @@
   background-color: currentColor;
 }
 
+/*
+ * We also show the library icon in locations, which are forced to RTL.
+ */
+.frames .location .img.annotation-logo {
+  margin-inline-start: 4px;
+}
+
 /* Some elements are added to the DOM only to be printed into the clipboard
    when the user copy some elements. We don't want those elements to mess with
    the layout so we put them outside of the screen

--- a/src/components/shared/AccessibleImage.css
+++ b/src/components/shared/AccessibleImage.css
@@ -12,6 +12,10 @@
   mask-size: contain;
   mask-repeat: no-repeat;
   mask-position: center;
+  /* multicolor icons use background-image */
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
   /* do not let images shrink when used as flex children */
   flex-shrink: 0;
 }

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -9,10 +9,6 @@
 
 .source-icon {
   margin-inline-end: 4px;
-  /* multicolor icons use background-image */
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
 }
 
 /* Icons for frameworks and libs */

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -141,7 +141,9 @@
   mask-image: url(/images/sources/underscore.svg);
 }
 
-.img.vue {
+/* We use both 'Vue' and 'VueJS' when identifying frameworks */
+.img.vue,
+.img.vuejs {
   background-image: url(/images/sources/vuejs.svg);
   background-color: transparent !important;
 }


### PR DESCRIPTION
Fixes #8084

Ideally it would be great if we could return the framework name as `"Vue.js"` and the className as `vuejs`, rather than supporting two names (`"Vue"` and `"VueJS"`) and two classes (`"vue"` and `"vuejs"`), but I'm not sure how to do that and the CSS fix seems less risky.
