### PR TITLE
Fix #8040 - Correct Accordion header spacing and restore thin plus.svg icon

### DIFF
--- a/images/plus.svg
+++ b/images/plus.svg
@@ -2,5 +2,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-  <path d="M14 7H9V2a1 1 0 0 0-2 0v5H2a1 1 0 1 0 0 2h5v5a1 1 0 0 0 2 0V9h5a1 1 0 0 0 0-2z"/>
+  <path d="M8.5 8.5V14a.5.5 0 1 1-1 0V8.5H2a.5.5 0 0 1 0-1h5.5V2a.5.5 0 0 1 1 0v5.5H14a.5.5 0 1 1 0 1H8.5z"/>
 </svg>

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -4,12 +4,10 @@
 
 :root {
   --accordion-header-background: var(--theme-toolbar-background);
-  --disclosure-arrow: #b2b2b2;
 }
 
 :root.theme-dark {
   --accordion-header-background: #222225;
-  --disclosure-arrow: #7f7f81;
 }
 
 .accordion {
@@ -25,30 +23,53 @@
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
   font-size: 12px;
-  padding: 4px;
-  transition: all 0.25s ease;
+  line-height: calc(16 / 12);
+  padding: 4px 6px;
   width: 100%;
-  height: 24px;
   align-items: center;
   margin: 0px;
   font-weight: normal;
-
+  cursor: default;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
-  cursor: default;
 }
 
 .accordion ._header:hover {
   background-color: var(--theme-toolbar-background-hover);
 }
 
-.accordion ._header button svg,
-.accordion ._header:hover button svg {
-  fill: currentColor;
+.accordion ._header .arrow {
+  margin-inline-end: 4px;
+}
+
+.accordion ._header .header-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.accordion ._header .header-buttons {
+  display: flex;
+  margin-inline-start: auto;
+}
+
+.accordion ._header .header-buttons button {
+  color: var(--theme-body-color);
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0 2px;
+  width: 16px;
   height: 16px;
+}
+
+.accordion ._header .header-buttons button::-moz-focus-inner {
+  border: none;
+}
+
+.accordion ._header .header-buttons button .img {
+  display: block;
 }
 
 .accordion ._content {
@@ -58,33 +79,4 @@
 
 .accordion div:last-child ._content {
   border-bottom: none;
-}
-
-.accordion ._header .header-buttons {
-  display: flex;
-  margin-left: auto;
-  padding-right: 5px;
-}
-
-.accordion .header-buttons .add-button {
-  font-size: 180%;
-  text-align: center;
-  line-height: 16px;
-}
-
-.accordion .header-buttons button {
-  color: var(--theme-body-color);
-  border: none;
-  background: none;
-  padding: 0;
-  width: 16px;
-  height: 16px;
-}
-
-.accordion .header-buttons button::-moz-focus-inner {
-  border: none;
-}
-
-.accordion .arrow svg {
-  fill: var(--disclosure-arrow);
 }

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -70,7 +70,7 @@ class Accordion extends Component<Props, State> {
           onClick={() => this.handleHeaderClick(i)}
         >
           <AccessibleImage className={`arrow ${opened ? "expanded" : ""}`} />
-          {item.header}
+          <span className="header-label">{item.header}</span>
           {item.buttons ? (
             <div className="header-buttons" tabIndex="-1">
               {item.buttons}

--- a/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
@@ -17,7 +17,11 @@ exports[`Accordion basic render 1`] = `
       <AccessibleImage
         className="arrow expanded"
       />
-      Test Accordion Item 1
+      <span
+        className="header-label"
+      >
+        Test Accordion Item 1
+      </span>
     </h2>
     <div
       className="_content"
@@ -38,7 +42,11 @@ exports[`Accordion basic render 1`] = `
       <AccessibleImage
         className="arrow "
       />
-      Test Accordion Item 2
+      <span
+        className="header-label"
+      >
+        Test Accordion Item 2
+      </span>
       <div
         className="header-buttons"
         tabIndex="-1"
@@ -60,7 +68,11 @@ exports[`Accordion basic render 1`] = `
       <AccessibleImage
         className="arrow expanded"
       />
-      Test Accordion Item 3
+      <span
+        className="header-label"
+      >
+        Test Accordion Item 3
+      </span>
     </h2>
     <div
       className="_content"


### PR DESCRIPTION
This restores:
- the old "+" icon, to avoid shipping a lonely Photon icon in Firefox 67
- correct padding in the accordion header ()

Small improvements:
- Small improvements to spacing to match Matt's spec
- Fix button alignment in RTL
- Add spacing between buttons (e.g. in Watch expressions)
- If we are short on room, cut the label, instead of letting the text push the buttons to the right (sometimes outside of the header).

<img width="224" alt="ellipsis screenshot" src="https://user-images.githubusercontent.com/243601/53904969-a9f87980-4047-11e9-8694-89f14051890e.png">

__Testing plan:__

We need to test this with mochitest because last time we had similar changes to accordion headers, some tests broke. :(

A real possibility is that removing the `height:24px` (so that the header can be 25px, including the bottom border) shuffles some content around and a synthetic click misses. Or there is a synthetic click near the end of the header but the "+" button moved a little bit and this misses. Something like that. Help welcome. :D