### PR TITLE
Aligned breakpoints and XHR breakpoints panes

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -10,6 +10,11 @@
   user-select: none;
 }
 
+.breakpoints-list {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
 .breakpoints-list .breakpoint-heading {
   text-overflow: ellipsis;
   overflow: hidden;
@@ -18,10 +23,6 @@
   align-items: center;
   padding-top: 3px;
   padding-bottom: 3px;
-}
-
-.breakpoints-list .breakpoint-heading:nth-child(2) {
-  margin-top: 4px;
 }
 
 .breakpoints-list .breakpoint-heading .filename {
@@ -59,10 +60,6 @@
   padding-bottom: 3px;
   padding-top: 3px;
   user-select: none;
-}
-
-.breakpoints-list .breakpoint:last-child {
-  margin-bottom: 4px;
 }
 
 .breakpoints-exceptions-caught {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -17,18 +17,18 @@
 
 .breakpoints-list .breakpoint-heading {
   text-overflow: ellipsis;
-  overflow: hidden;
-  display: flex;
   width: 100%;
-  align-items: center;
-  padding-top: 3px;
-  padding-bottom: 3px;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.breakpoint-heading:not(:first-child) {
+  margin-top: 2px;
 }
 
 .breakpoints-list .breakpoint-heading .filename {
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 14px;
 }
 
 .breakpoints-list .breakpoint-heading .filename span {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -6,10 +6,6 @@
   margin: 2px 3px;
 }
 
-.pane.breakpoints-list {
-  padding-bottom: 0.35em;
-}
-
 .breakpoints-list * {
   user-select: none;
 }
@@ -20,11 +16,18 @@
   display: flex;
   width: 100%;
   align-items: center;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+.breakpoints-list .breakpoint-heading:nth-child(2) {
+  margin-top: 4px;
 }
 
 .breakpoints-list .breakpoint-heading .filename {
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 14px;
 }
 
 .breakpoints-list .breakpoint-heading .filename span {
@@ -34,10 +37,8 @@
 
 .breakpoints-list .breakpoint-heading,
 .breakpoints-list .breakpoint {
-  font-size: 12px;
   color: var(--theme-content-color1);
   position: relative;
-  transition: all 0.25s ease;
   cursor: pointer;
 }
 
@@ -45,46 +46,66 @@
 .breakpoints-list .breakpoint,
 .breakpoints-exceptions,
 .breakpoints-exceptions-caught {
-  padding: 0.25em 1em;
+  padding-inline-start: 16px;
+  padding-inline-end: 12px;
 }
 
 .breakpoints-exceptions {
-  padding-bottom: 0.5em;
-  padding-top: 0.5em;
+  padding-bottom: 3px;
+  padding-top: 3px;
   user-select: none;
 }
 
 .breakpoints-list .breakpoint {
-  min-height: var(--breakpoint-expression-height);
   overflow: hidden;
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+.breakpoints-list .breakpoint:last-child {
+  margin-bottom: 4px;
 }
 
 .breakpoints-exceptions-caught {
-  padding: 0 1em 0.5em 3em;
-  margin-top: -0.25em;
+  padding-bottom: 3px;
+  padding-top: 3px;
+  padding-inline-start: 36px;
 }
 
 html[dir="rtl"] .breakpoints-exceptions-caught {
   padding: 0 3em 0.5em 1em;
 }
 
+.breakpoints-exceptions-options {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xhr-breakpoints-pane .breakpoints-exceptions-options {
+  border-bottom: 1px solid var(--theme-splitter-color);
+}
+
 .breakpoints-exceptions-options:not(.empty) {
   border-bottom: 1px solid var(--theme-splitter-color);
-  margin-bottom: 3px;
 }
 
 .breakpoints-exceptions input,
 .breakpoints-exceptions-caught input {
   padding-inline-start: 2px;
+  margin-top: 0px;
+  margin-bottom: 0px;
   margin-inline-start: 0;
+  margin-inline-end: 2px;
   vertical-align: text-bottom;
 }
 
 .breakpoint-exceptions-label {
-  padding-top: 2px;
+  line-height: 14px;
   padding-inline-start: 2px;
   padding-inline-end: 8px;
   cursor: default;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .breakpoints-list .breakpoint,
@@ -133,6 +154,8 @@ html .breakpoints-list .breakpoint.paused {
   color: var(--theme-comment);
   min-width: 16px;
   text-align: end;
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 
 .breakpoints-list .breakpoint:hover .breakpoint-line {
@@ -144,24 +167,24 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoints-list .breakpoint-label {
-  max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
   display: inline-block;
-  padding-inline-end: 8px;
   cursor: pointer;
   flex-grow: 1;
   text-overflow: ellipsis;
   overflow: hidden;
-  padding-top: 2px;
   font-size: 11px;
 }
 
-.breakpoints-list .breakpoint-label,
+.breakpoints-list .breakpoint-label span,
 .breakpoint-line-close {
-  line-height: 1.4em;
+  display: inline-block;
+  line-height: 14px;
 }
 
 .breakpoint-checkbox {
-  margin-inline-start: 0;
+  margin-inline-start: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
   vertical-align: text-bottom;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -133,6 +133,10 @@ html .breakpoints-list .breakpoint.paused {
   background-color: var(--search-overlays-semitransparent);
 }
 
+.breakpoint-line-close {
+  margin-inline-start: 4px;
+}
+
 .breakpoints-list .breakpoint .breakpoint-line {
   font-size: 11px;
   color: var(--theme-comment);

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -93,7 +93,6 @@
 
 .breakpoint-exceptions-label {
   line-height: 14px;
-  padding-inline-start: 2px;
   padding-inline-end: 8px;
   cursor: default;
   overflow: hidden;

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -162,7 +162,7 @@ html .breakpoints-list .breakpoint.paused {
 
 .breakpoints-list .breakpoint-label span,
 .breakpoint-line-close {
-  display: inline-block;
+  display: inline;
   line-height: 14px;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -46,6 +46,11 @@
 .breakpoints-list .breakpoint,
 .breakpoints-exceptions,
 .breakpoints-exceptions-caught {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding-top: 2px;
+  padding-bottom: 2px;
   padding-inline-start: 16px;
   padding-inline-end: 12px;
 }
@@ -56,12 +61,6 @@
   user-select: none;
 }
 
-.breakpoints-list .breakpoint {
-  overflow: hidden;
-  padding-top: 2px;
-  padding-bottom: 2px;
-}
-
 .breakpoints-list .breakpoint:last-child {
   margin-bottom: 4px;
 }
@@ -70,10 +69,6 @@
   padding-bottom: 3px;
   padding-top: 3px;
   padding-inline-start: 36px;
-}
-
-html[dir="rtl"] .breakpoints-exceptions-caught {
-  padding: 0 3em 0.5em 1em;
 }
 
 .breakpoints-exceptions-options {
@@ -106,13 +101,6 @@ html[dir="rtl"] .breakpoints-exceptions-caught {
   cursor: default;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.breakpoints-list .breakpoint,
-.breakpoints-exceptions,
-.breakpoints-exceptions-caught {
-  display: flex;
-  align-items: center;
 }
 
 html[dir="rtl"] .breakpoints-list .breakpoint,

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -80,41 +80,39 @@ class Breakpoints extends Component<Props> {
     if (!breakpointSources.length) {
       return null;
     }
-    
+
     const sources = [
       ...breakpointSources.map(({ source, breakpoints }) => source)
     ];
 
     return (
       <div className="pane breakpoints-list">
-        {
-          breakpointSources.map(({ source, breakpoints, i }) => {
-            const path = getDisplayPath(source, sources);
-            const sortedBreakpoints = sortSelectedBreakpoints(
-              breakpoints,
-              selectedSource
-            );
+        {breakpointSources.map(({ source, breakpoints, i }) => {
+          const path = getDisplayPath(source, sources);
+          const sortedBreakpoints = sortSelectedBreakpoints(
+            breakpoints,
+            selectedSource
+          );
 
-            return [
-              <BreakpointHeading
+          return [
+            <BreakpointHeading
+              source={source}
+              sources={sources}
+              path={path}
+              key={source.url}
+            />,
+            ...sortedBreakpoints.map(breakpoint => (
+              <Breakpoint
+                breakpoint={breakpoint}
                 source={source}
-                sources={sources}
-                path={path}
-                key={source.url}
-              />,
-              ...sortedBreakpoints.map(breakpoint => (
-                <Breakpoint
-                  breakpoint={breakpoint}
-                  source={source}
-                  selectedSource={selectedSource}
-                  key={makeBreakpointId(
-                    getSelectedLocation(breakpoint, selectedSource)
-                  )}
-                />
-              ))
-            ];
-          })
-        }
+                selectedSource={selectedSource}
+                key={makeBreakpointId(
+                  getSelectedLocation(breakpoint, selectedSource)
+                )}
+              />
+            ))
+          ];
+        })}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -77,14 +77,18 @@ class Breakpoints extends Component<Props> {
 
   renderBreakpoints() {
     const { breakpointSources, selectedSource } = this.props;
+    if (!breakpointSources.length) {
+      return null;
+    }
+    
     const sources = [
       ...breakpointSources.map(({ source, breakpoints }) => source)
     ];
 
     return (
       <div className="pane breakpoints-list">
-        {[
-          ...breakpointSources.map(({ source, breakpoints, i }) => {
+        {
+          breakpointSources.map(({ source, breakpoints, i }) => {
             const path = getDisplayPath(source, sources);
             const sortedBreakpoints = sortSelectedBreakpoints(
               breakpoints,
@@ -110,7 +114,7 @@ class Breakpoints extends Component<Props> {
               ))
             ];
           })
-        ]}
+        }
       </div>
     );
   }
@@ -119,7 +123,7 @@ class Breakpoints extends Component<Props> {
     return (
       <div>
         {this.renderExceptionsOptions()}
-        {!!this.props.breakpointSources.length && this.renderBreakpoints()}
+        {this.renderBreakpoints()}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -81,41 +81,45 @@ class Breakpoints extends Component<Props> {
       ...breakpointSources.map(({ source, breakpoints }) => source)
     ];
 
-    return [
-      ...breakpointSources.map(({ source, breakpoints, i }) => {
-        const path = getDisplayPath(source, sources);
-        const sortedBreakpoints = sortSelectedBreakpoints(
-          breakpoints,
-          selectedSource
-        );
+    return (
+      <div className="pane breakpoints-list">
+        {[
+          ...breakpointSources.map(({ source, breakpoints, i }) => {
+            const path = getDisplayPath(source, sources);
+            const sortedBreakpoints = sortSelectedBreakpoints(
+              breakpoints,
+              selectedSource
+            );
 
-        return [
-          <BreakpointHeading
-            source={source}
-            sources={sources}
-            path={path}
-            key={source.url}
-          />,
-          ...sortedBreakpoints.map(breakpoint => (
-            <Breakpoint
-              breakpoint={breakpoint}
-              source={source}
-              selectedSource={selectedSource}
-              key={makeBreakpointId(
-                getSelectedLocation(breakpoint, selectedSource)
-              )}
-            />
-          ))
-        ];
-      })
-    ];
+            return [
+              <BreakpointHeading
+                source={source}
+                sources={sources}
+                path={path}
+                key={source.url}
+              />,
+              ...sortedBreakpoints.map(breakpoint => (
+                <Breakpoint
+                  breakpoint={breakpoint}
+                  source={source}
+                  selectedSource={selectedSource}
+                  key={makeBreakpointId(
+                    getSelectedLocation(breakpoint, selectedSource)
+                  )}
+                />
+              ))
+            ];
+          })
+        ]}
+      </div>
+    );
   }
 
   render() {
     return (
-      <div className="pane breakpoints-list">
+      <div>
         {this.renderExceptionsOptions()}
-        {this.renderBreakpoints()}
+        {!!this.props.breakpointSources.length && this.renderBreakpoints()}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -44,7 +44,7 @@
 .expressions-list {
   /* TODO: add normalize */
   margin: 0;
-  padding: 0;
+  padding: 4px 0px;
 }
 
 .expression-input-container {

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -57,3 +57,8 @@
   width: 20em;
   overflow: auto;
 }
+
+.secondary-panes input[type="checkbox"] {
+  margin: 0;
+  margin-inline-end: 4px;
+}

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -65,11 +65,11 @@
 }
 
 :root.theme-light .xhr-container:hover {
-  background-color: var(--theme-selection-background-hover);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 :root.theme-dark .xhr-container:hover {
-  background-color: var(--theme-selection-background-hover);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .xhr-label-method {

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -37,6 +37,7 @@
   padding: 3px 0px;
   flex-grow: 1;
   background-color: var(--theme-sidebar-background);
+  font-size: inherit;
   line-height: 14px;
   color: var(--theme-body-color);
 }

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -3,8 +3,9 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .xhr-input-container {
-  display: block;
+  display: flex;
   border: 1px solid transparent;
+
 }
 
 .xhr-input-container.focused {
@@ -19,27 +20,24 @@
   border: 1px solid red;
 }
 
-.xhr-container label {
-  display: flex;
-}
-
 .xhr-input-form {
   display: inline-flex;
   width: 100%;
-  padding: 0.5em 1em 0.5em 1em;
+  padding-inline-start: 20px;
+  padding-inline-end: 12px;
 }
 
 .xhr-checkbox {
   margin-inline-start: 0;
+  margin-inline-end: 4px;
 }
 
 .xhr-input-url {
   border: 1px;
-  padding: 0em 0.6em 0em 0.6em;
+  padding: 3px 0px;
   flex-grow: 1;
   background-color: var(--theme-sidebar-background);
-  font-size: 12px;
-  line-height: 18px;
+  line-height: 14px;
   color: var(--theme-body-color);
 }
 
@@ -57,12 +55,12 @@
   border-left: 4px solid transparent;
   width: 100%;
   color: var(--theme-body-color);
-  padding: 0.25em 1em;
+  padding-inline-start: 16px;
+  padding-inline-end: 12px;
   background-color: var(--theme-body-background);
   display: flex;
   align-items: center;
   position: relative;
-  min-height: var(--breakpoint-expression-height);
 }
 
 :root.theme-light .xhr-container:hover {
@@ -74,9 +72,9 @@
 }
 
 .xhr-label-method {
-  padding: 0px 2px 0px 2px;
-  line-height: 15px;
+  line-height: 14px;
   display: inline-block;
+  margin-inline-end: 2px;
 }
 
 .xhr-input-method {
@@ -96,27 +94,18 @@
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 0px 2px 0px 2px;
-  line-height: 15px;
-  font-size: 11px;
+  line-height: 14px;
 }
 
 .xhr-container label {
   flex-grow: 1;
   display: flex;
-  padding-inline-end: 36px;
   align-items: center;
   overflow-x: hidden;
 }
 
 .xhr-container__close-btn {
-  position: absolute;
-  top: calc(50% - 8px);
-}
-
-[dir="ltr"] .xhr-container__close-btn {
-  right: 12px;
-}
-
-[dir="rtl"] .xhr-container__close-btn {
-  left: 12px;
+  display: flex;
+  padding-top: 2px;
+  padding-bottom: 2px;
 }

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -5,7 +5,6 @@
 .xhr-input-container {
   display: flex;
   border: 1px solid transparent;
-
 }
 
 .xhr-input-container.focused {

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -74,7 +74,7 @@
 
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
-  font-size: 12px;
+  font-size: var(--theme-body-font-size);
 }
 
 .accordion div:last-child ._content {

--- a/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 function openFirstBreakpointContextMenu(dbg){
-  rightClickElement(dbg, "breakpointItem", 3);
+  rightClickElement(dbg, "breakpointItem", 2);
 }
 
 

--- a/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -144,7 +144,7 @@ add_task(async function() {
   is(bp.options.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, { hasCondition: true });
 
-  rightClickElement(dbg, "breakpointItem", 3);
+  rightClickElement(dbg, "breakpointItem", 2);
   info('select "remove condition"');
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.removeCondition);
   await waitForBreakpointWithoutCondition(dbg, "simple2", 5);

--- a/test/mochitest/browser_dbg-breakpoints.js
+++ b/test/mochitest/browser_dbg-breakpoints.js
@@ -65,7 +65,7 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 3);
   await addBreakpoint(dbg, "simple2", 5);
 
-  rightClickElement(dbg, "breakpointItem", 3);
+  rightClickElement(dbg, "breakpointItem", 2);
   const disableBreakpointDispatch = waitForDispatch(dbg, "DISABLE_BREAKPOINT");
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.disableSelf);
   await disableBreakpointDispatch;
@@ -75,7 +75,7 @@ add_task(async function() {
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 
-  rightClickElement(dbg, "breakpointItem", 3);
+  rightClickElement(dbg, "breakpointItem", 2);
   const enableBreakpointDispatch = waitForDispatch(dbg, "ENABLE_BREAKPOINT");
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.enableSelf);
   await enableBreakpointDispatch;


### PR DESCRIPTION
These are the Breakpoints and XHR Breakpoints changes from the [UX Alignment](https://github.com/firefox-devtools/ux/issues/45) issue. I put them together in the same PR since they share some styles in `Breakpoints.css`.

### Summary of Changes

- Changed breakpoints, XHR breakpoint, and option rows to 20px height
- Changed font sizes to 11px
- Changed pane content indentation to 20px
- Changed nesting indentation to 16px
- Removed inset-inline-end selector for XHR Breakpoints

<img width="441" alt="screen shot 2019-03-06 at 10 58 45 pm" src="https://user-images.githubusercontent.com/15959269/53931498-6b70b800-4063-11e9-95e8-112eb1a74293.png">