### PR TITLE
Fix eslint warnings in XHRBreakpoints.spec.js

### DIFF
--- a/src/components/SecondaryPanes/tests/XHRBreakpoints.spec.js
+++ b/src/components/SecondaryPanes/tests/XHRBreakpoints.spec.js
@@ -129,7 +129,7 @@ describe("XHR Breakpoints", function() {
     const xhrBreakpointsComponent = renderXHRBreakpointsComponent();
     xhrBreakpointsComponent.find(".xhr-input-url").simulate("focus");
 
-    var xhrInputContainer = xhrBreakpointsComponent.find(
+    const xhrInputContainer = xhrBreakpointsComponent.find(
       ".xhr-input-container"
     );
     expect(xhrInputContainer.hasClass("focused")).toBeTruthy();
@@ -159,7 +159,7 @@ describe("XHR Breakpoints", function() {
       propsOverride
     );
     xhrBreakpointsComponent.find(".xhr-input-url").simulate("focus");
-    var xhrInputContainer = xhrBreakpointsComponent.find(
+    let xhrInputContainer = xhrBreakpointsComponent.find(
       ".xhr-input-container"
     );
     expect(xhrInputContainer.hasClass("focused")).toBeTruthy();
@@ -201,7 +201,7 @@ describe("XHR Breakpoints", function() {
     expect(xhrBreakpointsComponent.state("clickedOnFormElement")).toBe(false);
 
     xhrBreakpointsComponent.find(".xhr-input-method").simulate("click");
-    var xhrInputContainer = xhrBreakpointsComponent.find(
+    const xhrInputContainer = xhrBreakpointsComponent.find(
       ".xhr-input-container"
     );
     expect(xhrInputContainer.hasClass("focused")).toBeTruthy();


### PR DESCRIPTION
Very low hanging fruit for removing some of the noisy eslint warnings on `yarn lint`:

> debugger/src/components/SecondaryPanes/tests/XHRBreakpoints.spec.js
>  132:5  warning  Unexpected var, use let or const instead  mozilla/var-only-at-top-level
>  162:5  warning  Unexpected var, use let or const instead  mozilla/var-only-at-top-level
>  204:5  warning  Unexpected var, use let or const instead  mozilla/var-only-at-top-level

I wanted to use `const` in every instance, but one is actually reassigned later in the same function, so I used a `let` there.