### PR TITLE
Fix #7951 - Keep scroll position of documents when changing tabs

### DIFF
--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -67,10 +67,7 @@ export const clearSelectedLocation = () => ({
  * @memberof actions/sources
  * @static
  */
-export function selectSourceURL(
-  url: string,
-  options: PartialPosition = { line: 1 }
-) {
+export function selectSourceURL(url: string, options: PartialPosition = {}) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
     const source = getSourceByURL(getState(), url);
     if (!source) {
@@ -87,10 +84,7 @@ export function selectSourceURL(
  * @memberof actions/sources
  * @static
  */
-export function selectSource(
-  sourceId: string,
-  options: PartialPosition = { line: 1 }
-) {
+export function selectSource(sourceId: string, options: PartialPosition = {}) {
   return async ({ dispatch }: ThunkArgs) => {
     const location = createLocation({ ...options, sourceId });
     return dispatch(selectSpecificLocation(location));
@@ -139,6 +133,11 @@ export function selectLocation(
 
     const tabSources = getSourcesForTabs(getState());
     if (!tabSources.includes(source)) {
+      // If the source wasn't already open, ensure the editor is scrolled
+      // to the first line
+      if (!location.line) {
+        location = { ...location, line: 1 };
+      }
       dispatch(addTab(source));
     }
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -35,7 +35,7 @@ import {
 } from "../../selectors";
 
 import type { SourceLocation, PartialPosition, Source } from "../../types";
-import type { ThunkArgs } from "../types";
+import { hasDocument } from "../../utils/editor";
 
 export const setSelectedLocation = (
   source: Source,
@@ -133,12 +133,16 @@ export function selectLocation(
 
     const tabSources = getSourcesForTabs(getState());
     if (!tabSources.includes(source)) {
-      // If the source wasn't already open, ensure the editor is scrolled
-      // to the first line
-      if (!location.line) {
-        location = { ...location, line: 1 };
-      }
       dispatch(addTab(source));
+    }
+
+    // If the source wasn't already open, ensure the editor is scrolled
+    // to the first line
+    if (
+      (!tabSources.includes(source) || !hasDocument(source.id)) &&
+      !location.line
+    ) {
+      location = { ...location, line: 1 };
     }
 
     dispatch(setSelectedLocation(source, location));

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -15,7 +15,7 @@ type IncompleteLocation = {
 
 export function createLocation({
   sourceId,
-  line = 1,
+  line,
   column,
   sourceUrl = ""
 }: IncompleteLocation): SourceLocation {


### PR DESCRIPTION
Fixes #7951

This isn't perfect but it's a big improvement over the current behavior.

Since `selectLocation` defaults to `1`, every time a document is selected, the first line is selected and highlighted.  One way to isolate knowing when we truly want line 1 is assigning line 1 to the location if the source isn't open yet and no line assigned.

Where this patch isn't perfect is when you open tabs and refresh the page; since the tabs exist, the scroll isn't changed.  It's almost as if documents aren't defaulting back to line 1...