### PR TITLE
Use CompiledModules instead of DebuggerModules in moz.build files

### DIFF
--- a/bin/copy-modules.js
+++ b/bin/copy-modules.js
@@ -54,7 +54,7 @@ DIRS += [
 __DIRS__
 ]
 
-DebuggerModules(
+CompiledModules(
 __FILES__
 )
 `;


### PR DESCRIPTION
We moved to `CompiledModules` for the JSX work.  This change will make releases 1 billion times easier.