### PR TITLE
Switch watch expression's delete button

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -72,6 +72,7 @@
   background-color: var(--theme-body-background);
   display: block;
   position: relative;
+  overflow: hidden;
   min-height: var(--breakpoint-expression-height);
 }
 
@@ -94,6 +95,12 @@
 
 .expression-container__close-btn {
   position: absolute;
+  /* hiding button outside of row until hovered or focused*/
+  top: -100px;
+}
+
+.expression-container:hover .expression-container__close-btn,
+.expression-container__close-btn:focus-within {
   top: calc(50% - 8px);
 }
 

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -95,7 +95,7 @@
 
 .expression-container__close-btn {
   position: absolute;
-  /* hiding button outside of row until hovered or focused*/
+  /* hiding button outside of row until hovered or focused */
   top: -100px;
 }
 


### PR DESCRIPTION
Fixes <#7868>

### Summary of Changes
Mimic what we have for breakpoint delete button.
* Hide the button outside of view.
* Display it when hover the container or tab to the delete button.

### Gif
* Mouse
![mouse](https://user-images.githubusercontent.com/38041280/54158127-362be780-4420-11e9-922f-bdf2b94e4f8e.gif)

* Tab. Hit enter at the end.
![tab](https://user-images.githubusercontent.com/38041280/54158317-a20e5000-4420-11e9-8fd5-0cf429bac2eb.gif)
