### PR TITLE
[Log Point] Fix log point context menu accelerator

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -243,17 +243,17 @@ functionSearch.key=CmdOrCtrl+Shift+O
 # key identifiers, not messages displayed to the user.
 toggleBreakpoint.key=CmdOrCtrl+B
 
-# LOCALIZATION NOTE (toggleCondPanel.key): A key shortcut to toggle
+# LOCALIZATION NOTE (toggleCondPanel.breakpoint.key): A key shortcut to toggle
 # the conditional panel for breakpoints.
 # Do not localize "CmdOrCtrl+Shift+B", or change the format of the string. These are
 # key identifiers, not messages displayed to the user.
-toggleCondPanel.key=CmdOrCtrl+Shift+B
+toggleCondPanel.breakpoint.key=CmdOrCtrl+Shift+B
 
-# LOCALIZATION NOTE (toggleLogPanel.key): A key shortcut to toggle
+# LOCALIZATION NOTE (toggleCondPanel.logPoint.key): A key shortcut to toggle
 # the conditional panel for log points.
 # Do not localize "CmdOrCtrl+Shift+Y", or change the format of the string. These are
 # key identifiers, not messages displayed to the user.
-toggleLogPanel.key=CmdOrCtrl+Shift+Y
+toggleCondPanel.logPoint.key=CmdOrCtrl+Shift+Y
 
 # LOCALIZATION NOTE (stepOut.key): A key shortcut to
 # step out.
@@ -1028,13 +1028,13 @@ anonymousFunction=<anonymous>
 shortcuts.toggleBreakpoint=Toggle Breakpoint
 shortcuts.toggleBreakpoint.accesskey=B
 
-# LOCALIZATION NOTE (shortcuts.toggleCondPanel): text describing
+# LOCALIZATION NOTE (shortcuts.toggleCondPanel.breakpoint): text describing
 # keyboard shortcut action for toggling conditional panel for breakpoints
-shortcuts.toggleCondPanel=Edit Conditional Breakpoint
+shortcuts.toggleCondPanel.breakpoint=Edit Conditional Breakpoint
 
-# LOCALIZATION NOTE (shortcuts.toggleLogPanel): text describing
+# LOCALIZATION NOTE (shortcuts.toggleCondPanel.logPoint): text describing
 # keyboard shortcut action for toggling conditional panel for log points
-shortcuts.toggleLogPanel=Edit Log Point
+shortcuts.toggleCondPanel.logPoint=Edit Log Point
 
 # LOCALIZATION NOTE (shortcuts.pauseOrResume): text describing
 # keyboard shortcut action for pause of resume

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -244,10 +244,16 @@ functionSearch.key=CmdOrCtrl+Shift+O
 toggleBreakpoint.key=CmdOrCtrl+B
 
 # LOCALIZATION NOTE (toggleCondPanel.key): A key shortcut to toggle
-# the conditional breakpoint panel.
+# the conditional panel for breakpoints.
 # Do not localize "CmdOrCtrl+Shift+B", or change the format of the string. These are
 # key identifiers, not messages displayed to the user.
 toggleCondPanel.key=CmdOrCtrl+Shift+B
+
+# LOCALIZATION NOTE (toggleLogPanel.key): A key shortcut to toggle
+# the conditional panel for log points.
+# Do not localize "CmdOrCtrl+Shift+Y", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
+toggleLogPanel.key=CmdOrCtrl+Shift+Y
 
 # LOCALIZATION NOTE (stepOut.key): A key shortcut to
 # step out.
@@ -1023,8 +1029,12 @@ shortcuts.toggleBreakpoint=Toggle Breakpoint
 shortcuts.toggleBreakpoint.accesskey=B
 
 # LOCALIZATION NOTE (shortcuts.toggleCondPanel): text describing
-# keyboard shortcut action for toggling conditional panel keyboard
-shortcuts.toggleCondPanel=Toggle Conditional Panel
+# keyboard shortcut action for toggling conditional panel for breakpoints
+shortcuts.toggleCondPanel=Edit Conditional Breakpoint
+
+# LOCALIZATION NOTE (shortcuts.toggleLogPanel): text describing
+# keyboard shortcut action for toggling conditional panel for log points
+shortcuts.toggleLogPanel=Edit Log Point
 
 # LOCALIZATION NOTE (shortcuts.pauseOrResume): text describing
 # keyboard shortcut action for pause of resume

--- a/src/actions/sources/tests/__snapshots__/newSources.spec.js.snap
+++ b/src/actions/sources/tests/__snapshots__/newSources.spec.js.snap
@@ -7,10 +7,3 @@ Array [
   "http://localhost:8000/examples/base.js?v=2",
 ]
 `;
-
-exports[`sources - new sources sources - sources with querystrings should find two sources when same source with querystring 1`] = `
-Array [
-  "http://localhost:8000/examples/base.js?v=1",
-  "http://localhost:8000/examples/base.js?v=2",
-]
-`;

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -220,11 +220,11 @@ class Editor extends PureComponent<Props, State> {
 
     shortcuts.on(L10N.getStr("toggleBreakpoint.key"), this.onToggleBreakpoint);
     shortcuts.on(
-      L10N.getStr("toggleCondPanel.key"),
+      L10N.getStr("toggleCondPanel.breakpoint.key"),
       this.onToggleConditionalPanel
     );
     shortcuts.on(
-      L10N.getStr("toggleLogPanel.key"),
+      L10N.getStr("toggleCondPanel.logPoint.key"),
       this.onToggleConditionalPanel
     );
     shortcuts.on(L10N.getStr("sourceTabs.closeTab.key"), this.onClosePress);
@@ -256,8 +256,8 @@ class Editor extends PureComponent<Props, State> {
     const shortcuts = this.context.shortcuts;
     shortcuts.off(L10N.getStr("sourceTabs.closeTab.key"));
     shortcuts.off(L10N.getStr("toggleBreakpoint.key"));
-    shortcuts.off(L10N.getStr("toggleCondPanel.key"));
-    shortcuts.off(L10N.getStr("toggleLogPanel.key"));
+    shortcuts.off(L10N.getStr("toggleCondPanel.breakpoint.key"));
+    shortcuts.off(L10N.getStr("toggleCondPanel.logPoint.key"));
     shortcuts.off(searchAgainPrevKey);
     shortcuts.off(searchAgainKey);
   }
@@ -310,7 +310,7 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    const isLog = key === L10N.getStr("toggleLogPanel.key");
+    const isLog = key === L10N.getStr("toggleCondPanel.logPoint.key");
     this.toggleConditionalPanel(line, isLog);
   };
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -310,11 +310,8 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    if (key === L10N.getStr("toggleLogPanel.key")) {
-      this.toggleConditionalPanel(line, true);
-    } else {
-      this.toggleConditionalPanel(line);
-    }
+    const isLog = key === L10N.getStr("toggleLogPanel.key");
+    this.toggleConditionalPanel(line, isLog);
   };
 
   onEditorScroll = debounce(this.props.updateViewport, 200);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -305,7 +305,7 @@ class Editor extends PureComponent<Props, State> {
     e.stopPropagation();
     e.preventDefault();
     const line = this.getCurrentLine();
-    
+
     if (typeof line !== "number") {
       return;
     }
@@ -479,11 +479,14 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    return openConditionalPanel({
-      line: line,
-      sourceId: selectedSource.id,
-      sourceUrl: selectedSource.url
-    }, log);
+    return openConditionalPanel(
+      {
+        line: line,
+        sourceId: selectedSource.id,
+        sourceUrl: selectedSource.url
+      },
+      log
+    );
   };
 
   shouldScrollToLocation(nextProps) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -223,6 +223,10 @@ class Editor extends PureComponent<Props, State> {
       L10N.getStr("toggleCondPanel.key"),
       this.onToggleConditionalPanel
     );
+    shortcuts.on(
+      L10N.getStr("toggleLogPanel.key"),
+      this.onToggleConditionalPanel
+    );
     shortcuts.on(L10N.getStr("sourceTabs.closeTab.key"), this.onClosePress);
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
@@ -253,6 +257,7 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.off(L10N.getStr("sourceTabs.closeTab.key"));
     shortcuts.off(L10N.getStr("toggleBreakpoint.key"));
     shortcuts.off(L10N.getStr("toggleCondPanel.key"));
+    shortcuts.off(L10N.getStr("toggleLogPanel.key"));
     shortcuts.off(searchAgainPrevKey);
     shortcuts.off(searchAgainKey);
   }
@@ -300,11 +305,16 @@ class Editor extends PureComponent<Props, State> {
     e.stopPropagation();
     e.preventDefault();
     const line = this.getCurrentLine();
+    
     if (typeof line !== "number") {
       return;
     }
 
-    this.toggleConditionalPanel(line);
+    if (key === L10N.getStr("toggleLogPanel.key")) {
+      this.toggleConditionalPanel(line, true);
+    } else {
+      this.toggleConditionalPanel(line);
+    }
   };
 
   onEditorScroll = debounce(this.props.updateViewport, 200);
@@ -453,7 +463,7 @@ class Editor extends PureComponent<Props, State> {
     }
   }
 
-  toggleConditionalPanel = line => {
+  toggleConditionalPanel = (line, log: boolean = false) => {
     const {
       conditionalPanelLocation,
       closeConditionalPanel,
@@ -473,7 +483,7 @@ class Editor extends PureComponent<Props, State> {
       line: line,
       sourceId: selectedSource.id,
       sourceUrl: selectedSource.url
-    });
+    }, log);
   };
 
   shouldScrollToLocation(nextProps) {

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -39,7 +39,7 @@ export const addConditionalBreakpointItem = (
 ) => ({
   id: "node-menu-add-conditional-breakpoint",
   label: L10N.getStr("editor.addConditionBreakpoint"),
-  accelerator: L10N.getStr("toggleCondPanel.key"),
+  accelerator: L10N.getStr("toggleCondPanel.breakpoint.key"),
   accesskey: L10N.getStr("editor.addConditionBreakpoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location)
@@ -51,7 +51,7 @@ export const editConditionalBreakpointItem = (
 ) => ({
   id: "node-menu-edit-conditional-breakpoint",
   label: L10N.getStr("editor.editConditionBreakpoint"),
-  accelerator: L10N.getStr("toggleCondPanel.key"),
+  accelerator: L10N.getStr("toggleCondPanel.breakpoint.key"),
   accesskey: L10N.getStr("editor.addConditionBreakpoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location)
@@ -79,7 +79,7 @@ export const addLogPointItem = (
   accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location, true),
-  accelerator: L10N.getStr("toggleLogPanel.key")
+  accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
 });
 
 export const editLogPointItem = (
@@ -91,7 +91,7 @@ export const editLogPointItem = (
   accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location, true),
-  accelerator: L10N.getStr("toggleLogPanel.key")
+  accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
 });
 
 export const logPointItem = (

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -79,7 +79,7 @@ export const addLogPointItem = (
   accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location, true),
-  accelerator: L10N.getStr("toggleCondPanel.key")
+  accelerator: L10N.getStr("toggleLogPanel.key")
 });
 
 export const editLogPointItem = (
@@ -91,7 +91,7 @@ export const editLogPointItem = (
   accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location, true),
-  accelerator: L10N.getStr("toggleCondPanel.key")
+  accelerator: L10N.getStr("toggleLogPanel.key")
 });
 
 export const logPointItem = (

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -205,7 +205,8 @@ export default function showContextMenu(props: Props) {
     click: () => {
       selectSpecificLocation(selectedLocation);
       openConditionalPanel(selectedLocation);
-    }
+    },
+    accelerator: L10N.getStr("toggleCondPanel.breakpoint.key")
   };
 
   const editConditionItem = {
@@ -215,7 +216,8 @@ export default function showContextMenu(props: Props) {
     click: () => {
       selectSpecificLocation(selectedLocation);
       openConditionalPanel(selectedLocation);
-    }
+    },
+    accelerator: L10N.getStr("toggleCondPanel.breakpoint.key")
   };
 
   const addLogPointItem = {
@@ -224,7 +226,7 @@ export default function showContextMenu(props: Props) {
     accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
     disabled: false,
     click: () => openConditionalPanel(selectedLocation, true),
-    accelerator: L10N.getStr("toggleCondPanel.key")
+    accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
   };
 
   const editLogPointItem = {
@@ -233,7 +235,7 @@ export default function showContextMenu(props: Props) {
     accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
     disabled: false,
     click: () => openConditionalPanel(selectedLocation, true),
-    accelerator: L10N.getStr("toggleCondPanel.key")
+    accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
   };
 
   const removeLogPointItem = {

--- a/src/components/ShortcutsModal.js
+++ b/src/components/ShortcutsModal.js
@@ -46,12 +46,12 @@ export class ShortcutsModal extends Component<Props> {
           formatKeyShortcut(L10N.getStr("toggleBreakpoint.key"))
         )}
         {this.renderShorcutItem(
-          L10N.getStr("shortcuts.toggleCondPanel"),
-          formatKeyShortcut(L10N.getStr("toggleCondPanel.key"))
+          L10N.getStr("shortcuts.toggleCondPanel.breakpoint"),
+          formatKeyShortcut(L10N.getStr("toggleCondPanel.breakpoint.key"))
         )}
         {this.renderShorcutItem(
-          L10N.getStr("shortcuts.toggleLogPanel"),
-          formatKeyShortcut(L10N.getStr("toggleLogPanel.key"))
+          L10N.getStr("shortcuts.toggleCondPanel.logPoint"),
+          formatKeyShortcut(L10N.getStr("toggleCondPanel.logPoint.key"))
         )}
       </ul>
     );

--- a/src/components/ShortcutsModal.js
+++ b/src/components/ShortcutsModal.js
@@ -49,6 +49,10 @@ export class ShortcutsModal extends Component<Props> {
           L10N.getStr("shortcuts.toggleCondPanel"),
           formatKeyShortcut(L10N.getStr("toggleCondPanel.key"))
         )}
+        {this.renderShorcutItem(
+          L10N.getStr("shortcuts.toggleLogPanel"),
+          formatKeyShortcut(L10N.getStr("toggleLogPanel.key"))
+        )}
       </ul>
     );
   }

--- a/src/components/test/__snapshots__/ShortcutsModal.spec.js.snap
+++ b/src/components/test/__snapshots__/ShortcutsModal.spec.js.snap
@@ -33,7 +33,7 @@ exports[`ShortcutsModal renders when enabled 1`] = `
         </li>
         <li>
           <span>
-            Toggle Conditional Panel
+            Edit Conditional Breakpoint
           </span>
           <span>
             <span
@@ -41,6 +41,19 @@ exports[`ShortcutsModal renders when enabled 1`] = `
               key="Ctrl+Shift+B"
             >
               Ctrl+Shift+B
+            </span>
+          </span>
+        </li>
+        <li>
+          <span>
+            Edit Log Point
+          </span>
+          <span>
+            <span
+              className="keystroke"
+              key="Ctrl+Shift+Y"
+            >
+              Ctrl+Shift+Y
             </span>
           </span>
         </li>


### PR DESCRIPTION
Fixes #7692

### Summary of Changes

* Created new keyboard shortcut(`CmdOrCtrl+Shift+Y`) for toggling conditional panel for log points
* Updated log points context menu accelerator 
* Updated ShortcutsModal with new keyboard shortcut for log points
* Changed shortcut description for `shortcuts.toggleCondPanel` from `Toggle Conditional Panel` to `Edit Conditional Breakpoint`
* Updated snapshot testing

