### PR TITLE
Display Date object using `toString` instead of `toISOString`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --headless --",
     "mochici": "mochii --mc ./firefox --ci --default-test-path devtools/client/debugger/new --headless --",
-    "test": "jest",
+    "test": "TZ=Africa/Nairobi jest",
     "test:watch": "jest --watch",
     "test:coverage": "yarn test --coverage",
     "test:all": "yarn test; yarn lint; yarn flow",

--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -9,7 +9,7 @@
     "firefox": "./node_modules/.bin/start-firefox --start --location https://firefox-devtools.github.io/debugger-examples/",
     "chrome": "./node_modules/.bin/start-chrome",
     "license-check": "devtools-license-check",
-    "test": "jest --projects jest.config.js"
+    "test": "TZ=Africa/Nairobi jest --projects jest.config.js"
   },
   "author": "",
   "license": "MPL-2.0",

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -24,9 +24,10 @@ function DateTime(props) {
   try {
     const dateObject = new Date(grip.preview.timestamp);
     dateObject.toISOString();
-    date = span({
-      "data-link-actor-id": grip.actor,
-      className: "objectBox"
+    date = span(
+      {
+        "data-link-actor-id": grip.actor,
+        className: "objectBox"
       },
       getTitle(grip),
       span({ className: "Date" }, dateObject.toString())
@@ -39,9 +40,10 @@ function DateTime(props) {
 }
 
 function getTitle(grip) {
-  return span({
-    className: "objectTitle"
-  },
+  return span(
+    {
+      className: "objectTitle"
+    },
     `${grip.class} `
   );
 }

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -30,7 +30,7 @@ function DateTime(props) {
       getTitle(grip),
       span(
         { className: "Date" },
-        new Date(grip.preview.timestamp).toLocaleDateString()
+        new Date(grip.preview.timestamp).toString()
       )
     );
   } catch (e) {

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -28,9 +28,7 @@ function DateTime(props) {
         className: "objectBox"
       },
       getTitle(grip),
-      span(
-        { className: "Date" },
-        new Date(grip.preview.timestamp).toString()
+      span({ className: "Date" }, new Date(grip.preview.timestamp).toString()
       )
     );
   } catch (e) {

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -25,8 +25,8 @@ function DateTime(props) {
     const dateObject = new Date(grip.preview.timestamp);
     dateObject.toISOString();
     date = span({
-        "data-link-actor-id": grip.actor,
-        className: "objectBox"
+      "data-link-actor-id": grip.actor,
+      className: "objectBox"
       },
       getTitle(grip),
       span({ className: "Date" }, dateObject.toString())
@@ -40,8 +40,8 @@ function DateTime(props) {
 
 function getTitle(grip) {
   return span({
-      className: "objectTitle"
-    },
+    className: "objectTitle"
+  },
     `${grip.class} `
   );
 }

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -30,7 +30,7 @@ function DateTime(props) {
       getTitle(grip),
       span(
         { className: "Date" },
-        new Date(grip.preview.timestamp).toISOString()
+        new Date(grip.preview.timestamp).toLocaleDateString()
       )
     );
   } catch (e) {

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -28,8 +28,7 @@ function DateTime(props) {
         className: "objectBox"
       },
       getTitle(grip),
-      span({ className: "Date" }, new Date(grip.preview.timestamp).toString()
-      )
+      span({ className: "Date" }, new Date(grip.preview.timestamp).toString())
     );
   } catch (e) {
     date = span({ className: "objectBox" }, "Invalid Date");

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -26,7 +26,7 @@ function DateTime(props) {
     // Calling `toISOString` will throw if the date is invalid,
     // so we can render an `Invalid Date` element.
     dateObject.toISOString();
-    
+
     date = span(
       {
         "data-link-actor-id": grip.actor,

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -22,13 +22,14 @@ function DateTime(props) {
   const grip = props.object;
   let date;
   try {
-    date = span(
-      {
+    const dateObject = new Date(grip.preview.timestamp);
+    dateObject.toISOString();
+    date = span({
         "data-link-actor-id": grip.actor,
         className: "objectBox"
       },
       getTitle(grip),
-      span({ className: "Date" }, new Date(grip.preview.timestamp).toString())
+      span({ className: "Date" }, dateObject.toString())
     );
   } catch (e) {
     date = span({ className: "objectBox" }, "Invalid Date");
@@ -38,8 +39,7 @@ function DateTime(props) {
 }
 
 function getTitle(grip) {
-  return span(
-    {
+  return span({
       className: "objectTitle"
     },
     `${grip.class} `

--- a/packages/devtools-reps/src/reps/date-time.js
+++ b/packages/devtools-reps/src/reps/date-time.js
@@ -23,7 +23,10 @@ function DateTime(props) {
   let date;
   try {
     const dateObject = new Date(grip.preview.timestamp);
+    // Calling `toISOString` will throw if the date is invalid,
+    // so we can render an `Invalid Date` element.
     dateObject.toISOString();
+    
     date = span(
       {
         "data-link-actor-id": grip.actor,

--- a/packages/devtools-reps/src/reps/tests/date-time.js
+++ b/packages/devtools-reps/src/reps/tests/date-time.js
@@ -26,7 +26,7 @@ describe("test DateTime", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual("Date 2016-03-30T21:17:24.859Z");
+    expect(renderedComponent.text()).toEqual("Date Thu Mar 31 2016 00:17:24 GMT+0300 (East Africa Time)");
     expectActorAttribute(renderedComponent, stub.actor);
   });
 });
@@ -41,6 +41,6 @@ describe("test invalid DateTime", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual("Invalid Date");
+    expect(renderedComponent.text()).toEqual("Date Invalid Date");
   });
 });

--- a/packages/devtools-reps/src/reps/tests/date-time.js
+++ b/packages/devtools-reps/src/reps/tests/date-time.js
@@ -26,7 +26,9 @@ describe("test DateTime", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual("Date Thu Mar 31 2016 00:17:24 GMT+0300 (East Africa Time)");
+    expect(renderedComponent.text()).toEqual(
+      "Date Thu Mar 31 2016 00:17:24 GMT+0300 (East Africa Time)"
+      );
     expectActorAttribute(renderedComponent, stub.actor);
   });
 });

--- a/packages/devtools-reps/src/reps/tests/date-time.js
+++ b/packages/devtools-reps/src/reps/tests/date-time.js
@@ -43,6 +43,6 @@ describe("test invalid DateTime", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual("Date Invalid Date");
+    expect(renderedComponent.text()).toEqual("Invalid Date");
   });
 });

--- a/packages/devtools-reps/src/reps/tests/date-time.js
+++ b/packages/devtools-reps/src/reps/tests/date-time.js
@@ -28,7 +28,7 @@ describe("test DateTime", () => {
 
     expect(renderedComponent.text()).toEqual(
       "Date Thu Mar 31 2016 00:17:24 GMT+0300 (East Africa Time)"
-      );
+    );
     expectActorAttribute(renderedComponent, stub.actor);
   });
 });


### PR DESCRIPTION
Fixes #6153

### Summary of Changes

* change date from` toISOString` to `toString` format

### Test Plan

I modified the already existing tests to accommodate the new feature since the return values of the date time was changed.

- [x] Tested the patch displays the given date in string format e.g `Date Thu Mar 31 2016 00:17:24 GMT+0300 (East Africa Time)`

- [x] Tested the patch defaults to `Date Invalid Date` when the given date is invalid

- [x] Change test timezone to East African Time.

![firefox-datetime](https://user-images.githubusercontent.com/17080976/54584805-64658480-4a29-11e9-8647-8f14fa9de7a8.png)

