### PR TITLE
Ux 41 on hover classes and functions variations outline panel

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
- .outline {
+.outline {
   overflow-y: hidden;
 }
 

--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.outline {
+ .outline {
   overflow-y: hidden;
 }
 
@@ -12,31 +12,32 @@
 }
 
 .outline-pane-info {
-  padding: 0.5em;
   width: 100%;
   font-style: italic;
   text-align: center;
+  padding: 0.5em;
   user-select: none;
   font-size: 12px;
   overflow: hidden;
 }
 
 .outline-list {
-  margin: 0;
-  padding: 0 0 4px 0;
-  position: absolute;
-  top: 38px;
-  bottom: 25px;
-  left: 0;
-  right: 0;
   list-style-type: none;
+  padding: 4px 0;
+  margin: 0;
+  font-family: var(--monospace-font-family);
   overflow: auto;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 25px;
 }
 
 .outline-list__class-list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
 }
 
 .outline-list__class-list .function-signature .function-name {
@@ -48,10 +49,11 @@
 }
 
 .outline-list h2 {
-  margin: 10px 0 10px 10px;
   font-weight: normal;
   font-size: 1em;
+  padding: 3px 0 3px 10px;
   color: var(--blue-55);
+  margin-top: 10px;
 }
 
 .outline-list h2:hover {
@@ -82,19 +84,19 @@
 }
 
 .outline-footer {
-  display: flex;
-  box-sizing: border-box;
+  background: var(--theme-body-background);
+  border-top: 1px solid var(--theme-splitter-color);
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  height: 25px;
-  background: var(--theme-body-background);
-  border-top: 1px solid var(--theme-splitter-color);
   opacity: 1;
   z-index: 1;
   -moz-user-select: none;
   user-select: none;
+  height: 25px;
+  box-sizing: border-box;
+  display: flex;
 }
 
 .theme-dark .outline-footer button {
@@ -103,10 +105,5 @@
 
 .outline-footer button.active {
   background: var(--theme-highlight-blue);
-  color: #ffffff;
-}
-
-.theme-dark .outline-footer button.active {
-  background: var(--theme-selection-background);
   color: #ffffff;
 }

--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -39,6 +39,10 @@
   list-style: none;
 }
 
+.outline-list__class-list > .outline-list__element {
+  padding-left: 2rem;
+}
+
 .outline-list__class-list .function-signature .function-name {
   color: var(--theme-highlight-green);
 }
@@ -47,15 +51,16 @@
   color: inherit;
 }
 
-.outline-list .outline-list__class h2 {
+.outline-list__class h2 {
   font-weight: normal;
   font-size: 1em;
-  padding: 3px 0 3px 10px;
+  padding: 3px 0;
+  padding-inline-start: 10px;
   color: var(--blue-55);
   margin: 0;
 }
 
-.outline-list .outline-list__class:not(:first-child) h2 {
+.outline-list__class:not(:first-child) h2 {
   margin-top: 12px;
 }
 
@@ -78,12 +83,11 @@
 }
 
 .outline-list > .outline-list__element {
-  padding-left: 0;
+  padding-inline-start: 1rem;
 }
 
 .outline-list__element-icon {
-  padding-right: 0.4rem;
-  padding-left: 1rem;
+  padding-inline-end: 0.4rem;
 }
 
 .outline-list__element:hover {

--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -12,32 +12,31 @@
 }
 
 .outline-pane-info {
+  padding: 0.5em;
   width: 100%;
   font-style: italic;
   text-align: center;
-  padding: 0.5em;
   user-select: none;
   font-size: 12px;
   overflow: hidden;
 }
 
 .outline-list {
-  list-style-type: none;
-  padding: 4px 0;
   margin: 0;
-  font-family: var(--monospace-font-family);
-  overflow: auto;
+  padding: 0 0 4px 0;
   position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
+  top: 38px;
   bottom: 25px;
+  left: 0;
+  right: 0;
+  list-style-type: none;
+  overflow: auto;
 }
 
 .outline-list__class-list {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
 }
 
 .outline-list__class-list .function-signature .function-name {
@@ -48,12 +47,16 @@
   color: inherit;
 }
 
-.outline-list h2 {
+.outline-list .outline-list__class h2 {
   font-weight: normal;
   font-size: 1em;
   padding: 3px 0 3px 10px;
   color: var(--blue-55);
-  margin-top: 10px;
+  margin: 0;
+}
+
+.outline-list .outline-list__class:not(:first-child) h2 {
+  margin-top: 12px;
 }
 
 .outline-list h2:hover {
@@ -74,6 +77,10 @@
   white-space: nowrap;
 }
 
+.outline-list > .outline-list__element {
+  padding-left: 0;
+}
+
 .outline-list__element-icon {
   padding-right: 0.4rem;
   padding-left: 1rem;
@@ -84,19 +91,19 @@
 }
 
 .outline-footer {
-  background: var(--theme-body-background);
-  border-top: 1px solid var(--theme-splitter-color);
+  display: flex;
+  box-sizing: border-box;
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
+  height: 25px;
+  background: var(--theme-body-background);
+  border-top: 1px solid var(--theme-splitter-color);
   opacity: 1;
   z-index: 1;
   -moz-user-select: none;
   user-select: none;
-  height: 25px;
-  box-sizing: border-box;
-  display: flex;
 }
 
 .theme-dark .outline-footer button {
@@ -105,5 +112,10 @@
 
 .outline-footer button.active {
   background: var(--theme-highlight-blue);
+  color: #ffffff;
+}
+
+.theme-dark .outline-footer button.active {
+  background: var(--theme-selection-background);
   color: #ffffff;
 }

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -177,12 +177,12 @@ export class Outline extends Component<Props, State> {
     );
 
     return (
-      <div className="outline-list__class" key={klass}>
+      <li className="outline-list__class" key={klass}>
         {heading}
         <ul className="outline-list__class-list">
           {classFunctions.map(func => this.renderFunction(func))}
         </ul>
-      </div>
+      </li>
     );
   }
 

--- a/src/components/test/__snapshots__/Outline.spec.js.snap
+++ b/src/components/test/__snapshots__/Outline.spec.js.snap
@@ -79,7 +79,7 @@ exports[`Outline renders outline renders functions by function class 1`] = `
     <ul
       className="outline-list devtools-monospace"
     >
-      <div
+      <li
         className="outline-list__class"
         key="x_klass"
       >
@@ -118,8 +118,8 @@ exports[`Outline renders outline renders functions by function class 1`] = `
             />
           </li>
         </ul>
-      </div>
-      <div
+      </li>
+      <li
         className="outline-list__class"
         key="a_klass"
       >
@@ -178,7 +178,7 @@ exports[`Outline renders outline renders functions by function class 1`] = `
             />
           </li>
         </ul>
-      </div>
+      </li>
     </ul>
     <div
       className="outline-footer bottom"
@@ -206,7 +206,7 @@ exports[`Outline renders outline renders functions by function class, alphabetic
     <ul
       className="outline-list devtools-monospace"
     >
-      <div
+      <li
         className="outline-list__class"
         key="x_klass"
       >
@@ -245,8 +245,8 @@ exports[`Outline renders outline renders functions by function class, alphabetic
             />
           </li>
         </ul>
-      </div>
-      <div
+      </li>
+      <li
         className="outline-list__class"
         key="a_klass"
       >
@@ -305,7 +305,7 @@ exports[`Outline renders outline renders functions by function class, alphabetic
             />
           </li>
         </ul>
-      </div>
+      </li>
     </ul>
     <div
       className="outline-footer bottom"


### PR DESCRIPTION
Fixes [UX#41](https://github.com/firefox-devtools/ux/issues/41)

### Summary of Changes

* Class title: changed from margin to padding, to match the spacing of the function;
* Class title: insert margin-top only if it's the first element on the list;
* Functions outside Class: they keep the 1st level spacing;
* Changed div to li when creating .outline-list__class elements.

Example:
![54314928-aae75900-45bb-11e9-8272-402df01d0cc6](https://user-images.githubusercontent.com/3901809/54383343-9a44ea80-4670-11e9-8fcc-4ace68fc482a.gif)


### Test Plan

Opened this file on the Debugger, at the Outline tab:
```javascript
// example script for testing
function eee() {}
class bbb {
  constructor() {
    this.test = 'bbb';
  }
}

class Example {
  constructor(name){
    this.name = name;
  }

  testMe() {
    return `Hello!`;
  }
}

class Example2 {
  constructor(name){
    this.name = name;
  }

  testMeAgain() {
    return `Hello!`;
  }
}
```

Check if the hover state of the Class and functions are spaced correctly.