### PR TITLE
Keep QuickOpenModal resultCount in bounds

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -69,10 +69,12 @@ type GotoLocationType = {
   column?: number
 };
 
+const maxResults = 100;
+
 function filter(values, query) {
   return fuzzyAldrin.filter(values, query, {
     key: "value",
-    maxResults: 1000
+    maxResults: maxResults
   });
 }
 
@@ -80,6 +82,13 @@ export class QuickOpenModal extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { results: null, selectedIndex: 0 };
+  }
+
+  setResults(results: ?Array<QuickOpenResult>) {
+    if (results) {
+      results = results.slice(0, maxResults);
+    }
+    this.setState({ results });
   }
 
   componentDidMount() {
@@ -121,7 +130,7 @@ export class QuickOpenModal extends Component<Props, State> {
     const { sources } = this.props;
     const results =
       query == "" ? sources : filter(sources, this.dropGoto(query));
-    return this.setState({ results });
+    return this.setResults(results);
   };
 
   searchSymbols = (query: string) => {
@@ -133,18 +142,18 @@ export class QuickOpenModal extends Component<Props, State> {
     results = results.filter(result => result.title !== "anonymous");
 
     if (query === "@" || query === "#") {
-      return this.setState({ results });
+      return this.setResults(results);
     }
-
-    this.setState({ results: filter(results, query.slice(1)) });
+    results = filter(results, query.slice(1));
+    return this.setResults(results);
   };
 
   searchShortcuts = (query: string) => {
     const results = formatShortcutResults();
     if (query == "?") {
-      this.setState({ results });
+      this.setResults(results);
     } else {
-      this.setState({ results: filter(results, query.slice(1)) });
+      this.setResults(filter(results, query.slice(1)));
     }
   };
 
@@ -152,12 +161,9 @@ export class QuickOpenModal extends Component<Props, State> {
     const { tabs, sources } = this.props;
     if (tabs.length > 0) {
       const tabUrls = tabs.map((tab: Tab) => tab.url);
-
-      this.setState({
-        results: sources.filter(source => tabUrls.includes(source.url))
-      });
+      this.setResults(sources.filter(source => tabUrls.includes(source.url)));
     } else {
-      this.setState({ results: sources.slice(0, 100) });
+      this.setResults(sources);
     }
   };
 
@@ -374,8 +380,7 @@ export class QuickOpenModal extends Component<Props, State> {
     if (!enabled) {
       return null;
     }
-    const newResults = results && results.slice(0, 100);
-    const items = this.highlightMatching(query, newResults || []);
+    const items = this.highlightMatching(query, results || []);
     const expanded = !!items && items.length > 0;
 
     return (
@@ -398,7 +403,7 @@ export class QuickOpenModal extends Component<Props, State> {
           }
           {...(this.isSourceSearch() ? { size: "big" } : {})}
         />
-        {newResults && (
+        {results && (
           <ResultList
             key="results"
             items={items}

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -209,7 +209,7 @@ describe("QuickOpenModal", () => {
     wrapper.find("input").simulate("change", { target: { value: "somefil" } });
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
-      maxResults: 1000
+      maxResults: 100
     });
   });
 
@@ -230,7 +230,7 @@ describe("QuickOpenModal", () => {
       .simulate("change", { target: { value: "somefil:33" } });
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
-      maxResults: 1000
+      maxResults: 100
     });
   });
 
@@ -257,7 +257,7 @@ describe("QuickOpenModal", () => {
 
       expect(filter).toHaveBeenCalledWith([], "someFunc", {
         key: "value",
-        maxResults: 1000
+        maxResults: 100
       });
     });
 


### PR DESCRIPTION
Fixes #8119 

Here's the Pull Request Doc
https://firefox-dev.tools/debugger/docs/pull-requests.html

### Summary of Changes

Added a conditional to keep resultCount (number returned from getResultCount) at 100 or less.  
This is contained in the traverseResults method, within QuickOpenModal.js. 

### Test Plan

Tested behavior based upon expected behavior described by @fvsch.

Example test plan:

- [x] There are 100 items displayed in Go To File input.
- [x] Clicking "Up" arrow key from index 0 cycles back to the last item (item 99).
- [x] Clicking the "Down" arrow from index 99 cycles up to the first list item (index 0).
- [x] Passed all unit tests locally.


### Screenshots/Videos (OPTIONAL)
![issue 8119](https://user-images.githubusercontent.com/32985125/54468062-7fdd4080-4746-11e9-9ce5-f62c63d52127.gif)

This is my first code PR, so greatly appreciate any and all feedback.  
Sorry for the extraneous commits (issues with git).
Thanks!
