### PR TITLE
8118/fix quick open modal nan bug

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -235,7 +235,8 @@ export class QuickOpenModal extends Component<Props, State> {
     const { selectedIndex, results } = this.state;
     const resultCount = this.getResultCount();
     const index = selectedIndex + direction;
-    const nextIndex = (index + resultCount) % resultCount;
+    const nextIndex =
+      resultCount > 0 ? (index + resultCount) % resultCount : resultCount;
 
     this.setState({ selectedIndex: nextIndex });
 

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -300,28 +300,6 @@ describe("QuickOpenModal", () => {
     expect(wrapper.state().results).toEqual(null);
   });
 
-  test("basic gotoSource search", () => {
-    const { wrapper } = generateModal(
-      {
-        enabled: true,
-        query: "",
-        searchType: "shortcuts"
-      },
-      "shallow"
-    );
-    wrapper.setState(() => ({
-      results: [],
-      selectedIndex: 0
-    }));
-    expect(wrapper.state().selectedIndex).toEqual(0);
-    const event = {
-      preventDefault: jest.fn(),
-      key: "ArrowDown"
-    };
-    wrapper.find("SearchInput").simulate("keydown", event);
-    expect(wrapper.state().selectedIndex).toEqual(0);
-  });
-
   describe("onEnter", () => {
     it("on Enter go to location", () => {
       const { wrapper, props } = generateModal(

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -300,6 +300,28 @@ describe("QuickOpenModal", () => {
     expect(wrapper.state().results).toEqual(null);
   });
 
+  test("basic gotoSource search", () => {
+    const { wrapper } = generateModal(
+      {
+        enabled: true,
+        query: "",
+        searchType: "shortcuts"
+      },
+      "shallow"
+    );
+    wrapper.setState(() => ({
+      results: [],
+      selectedIndex: 0
+    }));
+    expect(wrapper.state().selectedIndex).toEqual(0);
+    const event = {
+      preventDefault: jest.fn(),
+      key: "ArrowDown"
+    };
+    wrapper.find("SearchInput").simulate("keydown", event);
+    expect(wrapper.state().selectedIndex).toEqual(0);
+  });
+
   describe("onEnter", () => {
     it("on Enter go to location", () => {
       const { wrapper, props } = generateModal(

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -658,7 +658,7 @@ describe("QuickOpenModal", () => {
       }));
       wrapper.find("SearchInput").simulate("keydown", event);
       expect(event.preventDefault).toHaveBeenCalled();
-      expect(wrapper.state().selectedIndex).toEqual(NaN);
+      expect(wrapper.state().selectedIndex).toEqual(0);
       expect(props.selectSpecificLocation).not.toHaveBeenCalledWith();
       expect(props.highlightLineRange).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Fixes #8118 

### Summary of Changes
We setting the `selectedIndex` to `NaN` when you used the keys to navigate an empty result list in the `QuickOpenModal`. This would cause keyboard navigation to break going forward, because `NaN + any number = NaN`. 

- [x] Added failing jest test. Realized after we have a test for this already so, just updated that one and removed my new test.
- [x] Set selected index to 0 when results are empty

### Test Plan
- [x] Updated test for this

Manual test:
1. Open https://firefox-dev.tools/debugger-examples/examples/todomvc/
2. `Command + p`
3. type anything that gets no results in the list
4. use the arrow keys to navigate empty list of results
5. search for a file (ex. app)
6. use arrow keys to navigate results

![quickopendialogkeystrokes](https://user-images.githubusercontent.com/5448834/54481716-11f45000-47fe-11e9-90c2-fb135c9af4cd.gif)
