### PR TITLE
[QuickOpen] show the end of the path

### DIFF
--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -113,10 +113,12 @@
   word-break: break-all;
   /** https://searchfox.org/mozilla-central/source/devtools/client/themes/variables.css **/
   color: var(--grey-40);
-  margin-left: 15px;
+  margin-left: 5px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  direction: rtl; /* make ellipsis on the beginning of a string */
+  text-align: left;
 }
 
 .theme-dark .result-list.big li.selected .subtitle {

--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -113,7 +113,7 @@
   word-break: break-all;
   /** https://searchfox.org/mozilla-central/source/devtools/client/themes/variables.css **/
   color: var(--grey-40);
-  margin-left: 5px;
+  margin-left: 15px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -4,7 +4,6 @@
 
 // @flow
 import classnames from "classnames";
-import { endTruncateStr } from "./utils";
 import {
   isPretty,
   getFilename,
@@ -64,12 +63,11 @@ export function formatSourcesForList(source: Source, tabs: TabList) {
   const relativeUrlWithQuery = `${source.relativeUrl}${getSourceQueryString(
     source
   ) || ""}`;
-  const subtitle = endTruncateStr(relativeUrlWithQuery, 100);
-  const value = relativeUrlWithQuery;
+
   return {
-    value,
+    value: relativeUrlWithQuery,
     title,
-    subtitle,
+    subtitle: relativeUrlWithQuery,
     icon: tabs.some(tab => tab.url == source.url)
       ? "tab result-item-icon"
       : classnames(getSourceClassnames(source), "result-item-icon"),


### PR DESCRIPTION
Fixes #8124 
Implemented a version with showing only the end of the path.
I am not sure if we need ellipsis in the middle, because in most cases we care about last directories.

### Summary of Changes

* removed truncation in JS 
* added an ellipsis on the start of the line

### Screenshots/Videos 
![2019-03-17 12 08 58](https://user-images.githubusercontent.com/8305170/54489533-8d610a80-48ad-11e9-98c8-fcaa86251431.gif)