### PR TITLE
Fixed jsx-a11y/no-static-element-interactions warnings raised by jsx-a11y linter

### DIFF
--- a/src/components/A11yIntention.js
+++ b/src/components/A11yIntention.js
@@ -32,6 +32,7 @@ export default class A11yIntention extends React.Component<Props, State> {
         className={this.state.keyboard ? "A11y-keyboard" : "A11y-mouse"}
         onKeyDown={this.handleKeyDown}
         onMouseDown={this.handleMouseDown}
+        role="presentation"
       >
         {this.props.children}
       </div>

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -158,6 +158,7 @@ export class ConditionalPanel extends PureComponent<Props> {
         onClick={() => this.keepFocusOnInput()}
         onBlur={this.props.closeConditionalPanel}
         ref={node => (this.panelNode = node)}
+        role="presentation"
       >
         <div className="prompt">»</div>
         <input

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -187,12 +187,13 @@ export class Popup extends Component<Props, State> {
 
     const { location } = value;
     return (
-      <div
+      <button
         className="preview-popup"
+        id="preview-popup-id"
         onClick={() => selectSourceURL(location.url, { line: location.line })}
       >
         <PreviewFunction func={value} />
-      </div>
+      </button>
     );
   }
 

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -103,12 +103,16 @@ class Preview extends PureComponent<Props, State> {
 
     if (preview && !preview.updating) {
       const target = getElementFromPos(preview.cursorPos);
-      target && target.classList.add("preview-selection");
+      target &&
+        target.classList.add("preview-selection") &&
+        target.setAttribute("aria-describedby", "preview-popup-id");
     }
 
     if (prevProps.preview && !prevProps.preview.updating) {
       const target = getElementFromPos(prevProps.preview.cursorPos);
-      target && target.classList.remove("preview-selection");
+      target &&
+        target.classList.remove("preview-selection") &&
+        target.removeAttribute("aria-describedby");
     }
   }
 

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -204,20 +204,25 @@ class Tab extends PureComponent<Props> {
       <div
         className={className}
         key={sourceId}
-        onClick={handleTabClick}
         // Accommodate middle click to close tab
-        onMouseUp={e => e.button === 1 && closeTab(source)}
-        onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(source, false)}
+        role="tab"
       >
-        <SourceIcon
-          source={source}
-          shouldHide={icon => ["file", "javascript"].includes(icon)}
-        />
-        <div className="filename">
-          {getTruncatedFileName(source, query)}
-          {path && <span>{`../${path}/..`}</span>}
-        </div>
+        <button
+          className={className}
+          onClick={handleTabClick}
+          onMouseUp={e => e.button === 1 && closeTab(source)}
+          onContextMenu={e => this.onTabContextMenu(e, sourceId)}
+        >
+          <SourceIcon
+            source={source}
+            shouldHide={icon => ["file", "javascript"].includes(icon)}
+          />
+          <div className="filename">
+            {getTruncatedFileName(source, query)}
+            {path && <span>{`../${path}/..`}</span>}
+          </div>
+        </button>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -45,6 +45,15 @@
   vertical-align: bottom;
 }
 
+.source-tab button:first-child {
+  border: 0;
+}
+
+.source-tab button:first-child::before {
+  transform: none;
+  transition-property: none;
+}
+
 .source-tab::before {
   content: "";
   position: absolute;

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -141,7 +141,7 @@ class Tabs extends PureComponent<Props, State> {
 
     const onClick = () => selectSource(source.id);
     return (
-      <li key={source.id} onClick={onClick}>
+      <li key={source.id} onClick={onClick} role="menuitem">
         <AccessibleImage
           className={`dropdown-icon ${this.getIconClass(source)}`}
         />
@@ -157,7 +157,7 @@ class Tabs extends PureComponent<Props, State> {
     }
 
     return (
-      <div className="source-tabs" ref="sourceTabs">
+      <div className="source-tabs" role="tablist" ref="sourceTabs">
         {tabSources.map((source, index) => (
           <Tab key={index} source={source} />
         ))}

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -642,6 +642,7 @@ class Editor extends PureComponent<Props, State> {
     return (
       <div
         className={classnames("editor-wrapper")}
+        role="tabpanel"
         ref={c => (this.$editorWrapper = c)}
       >
         <div

--- a/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Editor When empty should render 1`] = `
 <div
   className="editor-wrapper"
+  role="tabpanel"
 >
   <div
     className="editor-mount devtools-monospace"

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -249,6 +249,7 @@ class SourceTreeItem extends Component<Props, State> {
         key={item.path}
         onClick={this.onClick}
         onContextMenu={e => this.onContextMenu(e, item)}
+        role="presentation"
       >
         {this.renderItemArrow()}
         {this.getIcon(item, depth)}

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
@@ -7,6 +7,7 @@ Object {
     key="mdn.com/one.js"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -146,6 +147,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"
@@ -234,6 +236,7 @@ Object {
     key="http://mdn.com/one.js"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -382,6 +385,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"
@@ -477,6 +481,7 @@ Object {
     key="root"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -605,6 +610,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"
@@ -680,6 +686,7 @@ Object {
     key="root"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -782,6 +789,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -844,6 +852,7 @@ Object {
     key="root"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -948,6 +957,7 @@ Object {
           className="node focused"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -1011,6 +1021,7 @@ Object {
     key="folder/"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow expanded"
@@ -1087,6 +1098,7 @@ Object {
           className="node focused"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow expanded"
@@ -1137,6 +1149,7 @@ Object {
     key="ng://"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -1237,6 +1250,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -1298,6 +1312,7 @@ Object {
     key="folder/"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -1370,6 +1385,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -1418,6 +1434,7 @@ Object {
     key="folder/"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow expanded"
@@ -1494,6 +1511,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow expanded"
@@ -1544,6 +1562,7 @@ Object {
     key="moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -1646,6 +1665,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -1708,6 +1728,7 @@ Object {
     key="webpack://"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <AccessibleImage
       className="arrow"
@@ -1808,6 +1829,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <AccessibleImage
             className="arrow"
@@ -1869,6 +1891,7 @@ Object {
     key="http://mdn.com/one.js"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -2010,6 +2033,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"
@@ -2099,6 +2123,7 @@ Object {
     key="mdn.com/one.js"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -2242,6 +2267,7 @@ Object {
           className="node focused"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"
@@ -2332,6 +2358,7 @@ Object {
     key="mdn.com/external%20file"
     onClick={[Function]}
     onContextMenu={[Function]}
+    role="presentation"
   >
     <span
       className="img no-arrow"
@@ -2473,6 +2500,7 @@ Object {
           className="node"
           onClick={[Function]}
           onContextMenu={[Function]}
+          role="presentation"
         >
           <span
             className="img no-arrow"

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -225,6 +225,8 @@ export class ProjectSearch extends Component<Props, State> {
       <div
         className={classnames("result", { focused })}
         onClick={() => setTimeout(() => this.selectMatchItem(match), 50)}
+        role="button"
+        tabIndex="0"
       >
         <span className="line-number" key={match.line}>
           {match.line}

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -50,6 +50,8 @@ class BreakpointHeading extends PureComponent<Props> {
         title={getFileURL(source, false)}
         onClick={() => selectSource(source.id)}
         onContextMenu={this.onContextMenu}
+        role="button"
+        tabIndex="0"
       >
         <SourceIcon
           source={source}

--- a/src/components/SecondaryPanes/Breakpoints/ExceptionOption.js
+++ b/src/components/SecondaryPanes/Breakpoints/ExceptionOption.js
@@ -20,13 +20,19 @@ export default function ExceptionOption({
   onChange
 }: ExceptionOptionProps) {
   return (
-    <div className={className} onClick={onChange}>
-      <input
-        type="checkbox"
-        checked={isChecked ? "checked" : ""}
-        onChange={e => e.stopPropagation() && onChange()}
-      />
-      <div className="breakpoint-exceptions-label">{label}</div>
+    <div className={className}>
+      <label
+        htmlFor="breakpoint-exceptions-checkbox"
+        className="breakpoint-exceptions-label"
+      >
+        <input
+          type="checkbox"
+          id="breakpoint-exceptions-checkbox"
+          checked={isChecked ? "checked" : ""}
+          onChange={onChange}
+        />
+        {label}
+      </label>
     </div>
   );
 }

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/ExceptionOption.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/ExceptionOption.spec.js.snap
@@ -3,17 +3,18 @@
 exports[`ExceptionOption renders with values 1`] = `
 <div
   className="testClassName"
-  onClick={[Function]}
 >
-  <input
-    checked="checked"
-    onChange={[Function]}
-    type="checkbox"
-  />
-  <div
+  <label
     className="breakpoint-exceptions-label"
+    htmlFor="breakpoint-exceptions-checkbox"
   >
+    <input
+      checked="checked"
+      id="breakpoint-exceptions-checkbox"
+      onChange={[Function]}
+      type="checkbox"
+    />
     testLabel
-  </div>
+  </label>
 </div>
 `;

--- a/src/components/SecondaryPanes/Workers.js
+++ b/src/components/SecondaryPanes/Workers.js
@@ -28,7 +28,7 @@ export class Workers extends Component<Props> {
     const { openWorkerToolbox } = this.props;
 
     return (
-      <div
+      <button
         className="worker"
         key={thread.actor}
         onClick={() => openWorkerToolbox(thread)}
@@ -37,7 +37,7 @@ export class Workers extends Component<Props> {
           <AccessibleImage className={"worker"} />
         </div>
         <div className="label">{getDisplayName(thread)}</div>
-      </div>
+      </button>
     );
   }
 

--- a/src/components/SecondaryPanes/tests/__snapshots__/XHRBreakpoints.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/XHRBreakpoints.spec.js.snap
@@ -25,18 +25,19 @@ exports[`XHR Breakpoints should render with 0 expressions passed from props 1`] 
       >
         <div
           className="breakpoints-exceptions"
-          onClick={[Function]}
         >
-          <input
-            checked=""
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
+          <label
             className="breakpoint-exceptions-label"
+            htmlFor="breakpoint-exceptions-checkbox"
           >
+            <input
+              checked=""
+              id="breakpoint-exceptions-checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
             Pause on any URL
-          </div>
+          </label>
         </div>
       </ExceptionOption>
     </div>
@@ -221,18 +222,19 @@ exports[`XHR Breakpoints should render with 8 expressions passed from props 1`] 
       >
         <div
           className="breakpoints-exceptions"
-          onClick={[Function]}
         >
-          <input
-            checked=""
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <div
+          <label
             className="breakpoint-exceptions-label"
+            htmlFor="breakpoint-exceptions-checkbox"
           >
+            <input
+              checked=""
+              id="breakpoint-exceptions-checkbox"
+              onChange={[Function]}
+              type="checkbox"
+            />
             Pause on any URL
-          </div>
+          </label>
         </div>
       </ExceptionOption>
     </div>

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -37,6 +37,8 @@ export class Dropdown extends Component<Props, State> {
         className="dropdown"
         onClick={this.toggleDropdown}
         style={{ display: this.state.dropdownShown ? "block" : "none" }}
+        role="menu"
+        tabIndex="0"
       >
         {this.props.panel}
       </div>
@@ -58,6 +60,7 @@ export class Dropdown extends Component<Props, State> {
         className="dropdown-mask"
         onClick={this.toggleDropdown}
         style={{ display: this.state.dropdownShown ? "block" : "none" }}
+        role="presentation"
       />
     );
   }

--- a/src/components/shared/Modal.js
+++ b/src/components/shared/Modal.js
@@ -23,7 +23,7 @@ type ModalProps = {
 export const transitionTimeout = 175;
 
 export class Modal extends React.Component<ModalProps> {
-  onClick = (e: SyntheticEvent<HTMLElement>) => {
+  onMouseDown = (e: SyntheticEvent<HTMLElement>) => {
     e.stopPropagation();
   };
 
@@ -31,10 +31,12 @@ export class Modal extends React.Component<ModalProps> {
     const { additionalClass, children, handleClose, status } = this.props;
 
     return (
-      <div className="modal-wrapper" onClick={handleClose}>
+      <div className="modal-wrapper">
         <div
           className={classnames("modal", additionalClass, status)}
-          onClick={this.onClick}
+          onMouseDown={this.onMouseDown}
+          onBlur={handleClose}
+          role="dialog"
         >
           {children}
         </div>

--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .popover {
+  padding: 0;
   position: fixed;
   z-index: 100;
 }

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -229,16 +229,14 @@ class Popover extends Component<Props, State> {
 
   renderPopover() {
     const { top, left, orientation, targetMid } = this.state.coords;
-    const { onMouseLeave, onKeyDown } = this.props;
     const arrow = this.getPopoverArrow(orientation, targetMid.x, targetMid.y);
 
     return (
       <div
+        open
         className={classNames("popover", `orientation-${orientation}`, {
           up: orientation === "up"
         })}
-        onMouseLeave={onMouseLeave}
-        onKeyDown={onKeyDown}
         style={{ top, left }}
         ref={c => (this.$popover = c)}
       >
@@ -250,14 +248,12 @@ class Popover extends Component<Props, State> {
 
   renderTooltip() {
     const { top, left } = this.state.coords;
-    const { onMouseLeave, onKeyDown } = this.props;
     return (
       <div
         className="tooltip"
-        onMouseLeave={onMouseLeave}
-        onKeyDown={onKeyDown}
         style={{ top, left }}
         ref={c => (this.$tooltip = c)}
+        role="tooltip"
       >
         {this.getChildren()}
       </div>

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -23,6 +23,9 @@ type Props = {
 };
 
 export default class ResultList extends Component<Props> {
+  onClick = (e: SyntheticEvent<HTMLElement>) => {
+    e.stopPropagation();
+  };
   displayName: "ResultList";
 
   static defaultProps = {
@@ -37,7 +40,7 @@ export default class ResultList extends Component<Props> {
 
     const { selectItem, selected } = this.props;
     const props = {
-      onClick: event => selectItem(event, item, index),
+      onMouseDown: event => selectItem(event, item, index),
       key: `${item.id}${item.value}${index}`,
       ref: String(index),
       title: item.value,

--- a/src/components/shared/tests/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Dropdown.spec.js.snap
@@ -7,11 +7,13 @@ exports[`Dropdown render 1`] = `
   <div
     className="dropdown"
     onClick={[Function]}
+    role="menu"
     style={
       Object {
         "display": "block",
       }
     }
+    tabIndex="0"
   >
     <div />
   </div>
@@ -24,6 +26,7 @@ exports[`Dropdown render 1`] = `
   <div
     className="dropdown-mask"
     onClick={[Function]}
+    role="presentation"
     style={
       Object {
         "display": "block",

--- a/src/components/shared/tests/__snapshots__/Modal.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Modal.spec.js.snap
@@ -3,11 +3,12 @@
 exports[`Modal renders 1`] = `
 <div
   className="modal-wrapper"
-  onClick={[Function]}
 >
   <div
     className="modal entering"
-    onClick={[Function]}
+    onBlur={[Function]}
+    onMouseDown={[Function]}
+    role="dialog"
   />
 </div>
 `;

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -26,8 +26,7 @@ exports[`Popover mount popover 1`] = `
 >
   <div
     className="popover orientation-right"
-    onKeyDown={[MockFunction]}
-    onMouseLeave={[MockFunction]}
+    open={true}
     style={
       Object {
         "left": 510,
@@ -88,8 +87,7 @@ exports[`Popover mount tooltip 1`] = `
 >
   <div
     className="tooltip"
-    onKeyDown={[MockFunction]}
-    onMouseLeave={[MockFunction]}
+    role="tooltip"
     style={
       Object {
         "left": -8,
@@ -111,8 +109,7 @@ exports[`Popover mount tooltip 1`] = `
 exports[`Popover render (tooltip) 1`] = `
 <div
   className="tooltip"
-  onKeyDown={[MockFunction]}
-  onMouseLeave={[MockFunction]}
+  role="tooltip"
   style={
     Object {
       "left": 0,
@@ -156,8 +153,7 @@ exports[`Popover render 1`] = `
 >
   <div
     className="popover orientation-right"
-    onKeyDown={[MockFunction]}
-    onMouseLeave={[MockFunction]}
+    open={true}
     style={
       Object {
         "left": 510,

--- a/src/components/shared/tests/__snapshots__/ResultList.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/ResultList.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Result list should render the component 1`] = `
     aria-labelledby="0-title"
     className="result-item"
     key="0value0"
-    onClick={[Function]}
+    onMouseDown={[Function]}
     role="option"
     title="value"
   >
@@ -34,7 +34,7 @@ exports[`Result list should render the component 1`] = `
     aria-labelledby="1-title"
     className="result-item selected"
     key="1value 11"
-    onClick={[Function]}
+    onMouseDown={[Function]}
     role="option"
     title="value 1"
   >

--- a/src/components/test/__snapshots__/A11yIntention.spec.js.snap
+++ b/src/components/test/__snapshots__/A11yIntention.spec.js.snap
@@ -5,6 +5,7 @@ exports[`A11yIntention renders its children 1`] = `
   className="A11y-mouse"
   onKeyDown={[Function]}
   onMouseDown={[Function]}
+  role="presentation"
 >
   <span>
     hello world

--- a/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
@@ -345,6 +345,8 @@ exports[`ProjectSearch found search results 1`] = `
                   <div
                     className="result"
                     onClick={[Function]}
+                    role="button"
+                    tabIndex="0"
                   >
                     <span
                       className="line-number"
@@ -413,6 +415,8 @@ exports[`ProjectSearch found search results 1`] = `
                   <div
                     className="result"
                     onClick={[Function]}
+                    role="button"
+                    tabIndex="0"
                   >
                     <span
                       className="line-number"
@@ -481,6 +485,8 @@ exports[`ProjectSearch found search results 1`] = `
                   <div
                     className="result"
                     onClick={[Function]}
+                    role="button"
+                    tabIndex="0"
                   >
                     <span
                       className="line-number"
@@ -621,6 +627,8 @@ exports[`ProjectSearch found search results 1`] = `
                   <div
                     className="result"
                     onClick={[Function]}
+                    role="button"
+                    tabIndex="0"
                   >
                     <span
                       className="line-number"
@@ -689,6 +697,8 @@ exports[`ProjectSearch found search results 1`] = `
                   <div
                     className="result"
                     onClick={[Function]}
+                    role="button"
+                    tabIndex="0"
                   >
                     <span
                       className="line-number"

--- a/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
@@ -49,11 +49,12 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -177,11 +178,12 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -288,11 +290,12 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -451,11 +454,12 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -567,11 +571,12 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={2}
@@ -647,7 +652,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                   aria-labelledby="undefined-title"
                   className="result-item selected"
                   key="undefinedundefined0"
-                  onClick={[Function]}
+                  onMouseDown={[Function]}
                   role="option"
                 >
                   <div
@@ -660,7 +665,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                   aria-labelledby="undefined-title"
                   className="result-item"
                   key="undefinedundefined1"
-                  onClick={[Function]}
+                  onMouseDown={[Function]}
                   role="option"
                 >
                   <div
@@ -726,11 +731,12 @@ exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -842,11 +848,12 @@ exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -969,11 +976,12 @@ exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] =
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -1085,11 +1093,12 @@ exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal entering"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}
@@ -1254,11 +1263,12 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
       >
         <div
           className="modal-wrapper"
-          onClick={[Function]}
         >
           <div
             className="modal exited"
-            onClick={[Function]}
+            onBlur={[Function]}
+            onMouseDown={[Function]}
+            role="dialog"
           >
             <SearchInput
               count={0}


### PR DESCRIPTION
Fixes issue #7537 

I know this generates errors from `yarn run test:all`. I'm looking for feedback on the current state of the fix to make sure I'm going in the right direction and everything looks correct so far. 

### Summary of Changes

* jsx-a11y linter raised "jsx-a11y/no-static-element-interactions" warnings. [Here is a description of the meaning of the warning.](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md)
* This commit makes changes to files in order to remove those generated warnings.
* I attempted to firstly use native HTML elements as opposed to adding unhelpful/inappropriate WAI-ARIA role, and added role values if I was unable to correct the warnings solely with restructuring the code just to use native HTML elements.

### Test Plan

To test:

- Run `yarn jest -u` to update your jest tests
- Then run `yarn run lint:jsx-a11y` to check the warnings from the jsx-a11y linter, or run `yarn run test:all` to run all the available tests

