### PR TITLE
[Column Breakpoints] Fixes toggling column breakpoints when Shift + clicking line breakpoint

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -97,7 +97,16 @@ class Breakpoint extends PureComponent<Props> {
     }
 
     if (event.shiftKey) {
-      return breakpointActions.toggleDisabledBreakpoint(breakpoint);
+      if (breakpoint.disabled) {
+        return breakpointActions.enableBreakpointsAtLine(
+          this.selectedLocation.sourceId,
+          this.selectedLocation.line
+        );
+      }
+      return breakpointActions.disableBreakpointsAtLine(
+        this.selectedLocation.sourceId,
+        this.selectedLocation.line
+      );
     }
 
     return breakpointActions.removeBreakpointsAtLine(


### PR DESCRIPTION
Fixes #8105.

### Summary of Changes

In the original code, when the the line breakpoint is Shift + clicked, `toggleDisabledBreakpoint` runs:

[Code Snippet](https://github.com/firefox-devtools/debugger/blob/8f424c3344d0e4a60c19344368a5eb92186d0680/src/components/Editor/Breakpoint.js#L99-L101)

The reason this does not actually toggle any of the column breakpoints is because `toggleDisabledBreakpoint` only toggles a single breakpoint and will not toggle any of the other column breakpoints on the line.

I decided to remain consistent with the logic used in the breakpoint context menu items that enable and disable breakpoints on the line:

[Code Snippet 1](https://github.com/firefox-devtools/debugger/blob/8f424c3344d0e4a60c19344368a5eb92186d0680/src/components/Editor/menus/breakpoints.js#L196)
[Code Snippet 2](https://github.com/firefox-devtools/debugger/blob/8f424c3344d0e4a60c19344368a5eb92186d0680/src/components/Editor/menus/breakpoints.js#L208)

I applied the above logic to the Shift + click shortcut. 

### Screenshots

**Demonstration of the Unwanted Behavior:**

![Issue_#8105_Image_Bug_1](https://user-images.githubusercontent.com/35577323/54859512-0a401a00-4cdc-11e9-9002-8299bf506af6.png)
Above: all column breakpoints on the line are enabled.

![Issue_#8015_Image_Bug_2](https://user-images.githubusercontent.com/35577323/54859516-14faaf00-4cdc-11e9-85db-a1ab3089bc67.jpg)
Above: after Shift + clicking the circled breakpoint, only the first column breakpoint is disabled.

**Demonstration of the Changed Behavior:**

![Issue_#8105_Image_Fixed_1](https://user-images.githubusercontent.com/35577323/54859523-2348cb00-4cdc-11e9-8cb2-8e463e4da008.png)
Above: all column breakpoints on the line are enabled.

![Issue_#8105_Image_Fixed_2](https://user-images.githubusercontent.com/35577323/54859525-29d74280-4cdc-11e9-9c73-63e6b8f10c9f.jpg)
Above: after Shift + clicking the circled breakpoint, all the column breakpoints are disabled.

![Issue_#8105_Image_Fixed_3](https://user-images.githubusercontent.com/35577323/54859549-a0744000-4cdc-11e9-9ac1-d4dad53cb926.jpg)
Above: after Shift + clicking the circled breakpoint, all the previously enabled column breakpoints are re-enabled.



### Test Plan

- [x] Shift + clicking the line breakpoint disables all enabled column breakpoints.
- [x] Shift + clicking on the line breakpoint re-enables all previously enabled column breakpoints.
- [x] If only a portion of the column breakpoints are enabled, Shift + clicking the line breakpoint toggles only the previously enabled column breakpoints.

