### PR TITLE
Show column number in Call Stack's Debug location / address

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -54,7 +54,11 @@ function FrameLocation({ frame, displayFullUrl = false }: FrameLocationProps) {
     <span className="location">
       <span className="filename">{filename}</span>:
       <span className="line">{location.line}</span>
-	  {location.column && <span>:<span className="column">{location.column}</span></span>}
+      {location.column && (
+        <span>
+          :<span className="column">{location.column}</span>
+        </span>
+      )}
     </span>
   );
 }

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -27,9 +27,17 @@ function FrameTitle({ frame, options = {}, l10n }: FrameTitleProps) {
   return <span className="title">{displayName}</span>;
 }
 
-type FrameLocationProps = { frame: Frame, displayFullUrl: boolean };
+type FrameLocationProps = {
+  frame: Frame,
+  displayFullUrl: boolean,
+  showCol: boolean
+};
 
-function FrameLocation({ frame, displayFullUrl = false }: FrameLocationProps) {
+function FrameLocation({
+  frame,
+  displayFullUrl = false,
+  showCol = false
+}: FrameLocationProps) {
   if (!frame.source) {
     return null;
   }
@@ -54,11 +62,12 @@ function FrameLocation({ frame, displayFullUrl = false }: FrameLocationProps) {
     <span className="location">
       <span className="filename">{filename}</span>:
       <span className="line">{location.line}</span>
-      {location.column && (
-        <span>
-          :<span className="column">{location.column}</span>
-        </span>
-      )}
+      {showCol &&
+        location.column && (
+          <React.Fragment>
+            :<span className="column">{location.column}</span>
+          </React.Fragment>
+        )}
     </span>
   );
 }
@@ -172,7 +181,11 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         />
         {!hideLocation && <span className="clipboard-only"> </span>}
         {!hideLocation && (
-          <FrameLocation frame={frame} displayFullUrl={displayFullUrl} />
+          <FrameLocation
+            frame={frame}
+            displayFullUrl={displayFullUrl}
+            showCol={true}
+          />
         )}
         {selectable && <br className="clipboard-only" />}
       </div>

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -54,6 +54,7 @@ function FrameLocation({ frame, displayFullUrl = false }: FrameLocationProps) {
     <span className="location">
       <span className="filename">{filename}</span>:
       <span className="line">{location.line}</span>
+	  {location.column && <span>:<span className="column">{location.column}</span></span>}
     </span>
   );
 }

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
@@ -108,6 +108,7 @@ exports[`Frame getFrameTitle 1`] = `
         "thread": "FakeThread",
       }
     }
+    showCol={true}
   />
   <br
     className="clipboard-only"
@@ -224,6 +225,7 @@ exports[`Frame library frame 1`] = `
         "thread": "FakeThread",
       }
     }
+    showCol={true}
   />
   <br
     className="clipboard-only"
@@ -338,6 +340,7 @@ exports[`Frame user frame (not selected) 1`] = `
         "thread": "FakeThread",
       }
     }
+    showCol={true}
   />
   <br
     className="clipboard-only"
@@ -452,6 +455,7 @@ exports[`Frame user frame 1`] = `
         "thread": "FakeThread",
       }
     }
+    showCol={true}
   />
   <br
     className="clipboard-only"


### PR DESCRIPTION
Fixes #8123 

I've ran the test cases, linter, not sure if anything else is pending. Please have a look.

### Summary of Changes

* Show column number in Call stack location
* Doesn't show col number if the column is `0`

### Screenshots
![debug](https://user-images.githubusercontent.com/227817/54864769-db7c7f00-4d81-11e9-91bd-beed83e2f4b7.png)
