### PR TITLE
Remove postcss-bidirection and postcss-class-namespace from dev build

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -34,13 +34,11 @@ module.exports = ({ file, options, env }) => {
 
   return {
     plugins: [
-      require("postcss-bidirection"),
       require("autoprefixer")({
         browsers: ["last 2 Firefox versions", "last 2 Chrome versions"],
         flexbox: false,
         grid: false
       }),
-      require("postcss-class-namespace")(),
       mapUrl(mapUrlDevelopment)
     ]
   };


### PR DESCRIPTION
Fixes #8155

### Summary of Changes

In the postcss config for the dev environment (aka for launchpad started with `yarn start`), remove two postcss plugins:

1. Re-remove `postcss-bidirection`, which was removed in #7941 together with its dependencies and reintroduced in Sync 130 _without_ its dependencies (https://github.com/firefox-devtools/debugger/commit/c4524619ee9f0ca50bda5c73505f08ce19085119#diff-b19118abc8e2dbd959e8a14a8c0edcd7R37). As far as I know, we don't want to use it anymore because both Firefox and Chrome have support for CSS logical properties and this polyfill creates selectors with higher specificity which leads to selector specificity battles.

2. Remove `postcss-class-namespace` because A) in practice we don't use it, the only usage I'm seeing is in `node_modules/devtools-mc-assets/assets/devtools/client/themes/dark-theme.css` and that file is included in the launchpad as-is, it's not processed by postcss at all (probably because webpack loaders are configured by default to exclude stuff from `node_modules`); and B) if we do use this feature at one point, then it will work only in the Launchpad and will break in Firefox, since we're only using it in the dev config. Better to just remove it IMO.
