### PR TITLE
Fixed Horizontal scrolling in the debugger secondary panel

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.breakpoints-pane > ._content {
+  overflow-x: auto;
+}
+
 .breakpoints-toggle {
   margin: 2px 3px;
 }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -49,6 +49,7 @@
   /* TODO: add normalize */
   margin: 0;
   padding: 4px 0px;
+  overflow-x: auto;
 }
 
 .expression-input-container {

--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -54,6 +54,9 @@ html[dir="rtl"] .object-node {
 
 .scopes-list {
   padding: 4px 0px;
+}
+
+.scopes-pane ._content {
   overflow: auto;
 }
 

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .secondary-panes {
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -4,6 +4,7 @@
 
 .secondary-panes {
   overflow-x: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .secondary-panes {
-  overflow: auto;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.xhr-breakpoints-pane ._content {
+  overflow-x: auto;
+}
+
 .xhr-input-container {
   display: flex;
   border: 1px solid transparent;

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -75,6 +75,7 @@
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: var(--theme-body-font-size);
+  overflow: auto;
 }
 
 .accordion div:last-child ._content {

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -75,7 +75,6 @@
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: var(--theme-body-font-size);
-  overflow: auto;
 }
 
 .accordion div:last-child ._content {


### PR DESCRIPTION
Fixes #8129

### Summary of Changes

* Fixed the horizontal overflow of the headers in the debugger secondary panel.

### Test Plan
- [x] Open the DevTools and go to Debugger tab
- [x] Run the Debugger or inspect Scopes
- [x] You can also increase the font size so elements overflow horizontally
- [x] Now the horizontal overflow scrolls only for the data inside each section, but not for the headers

