### PR TITLE
8064-footer

### DIFF
--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -52,7 +52,11 @@
   fill: var(--theme-body-color);
 }
 
-:root.theme-dark .source-footer > .source-footer-start > .commands > .action:hover {
+:root.theme-dark
+  .source-footer
+  > .source-footer-start
+  > .commands
+  > .action:hover {
   fill: var(--theme-selection-color);
 }
 
@@ -62,7 +66,11 @@
   margin: 0 4px;
 }
 
-.source-footer > .source-footer-start > .commands > .blackboxed > .img.blackBox {
+.source-footer
+  > .source-footer-start
+  > .commands
+  > .blackboxed
+  > .img.blackBox {
   background-color: var(--theme-icon-checked-color);
 }
 

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -34,7 +34,7 @@
   user-select: none;
 }
 
-.source-footer > .commands > .action {
+.source-footer > .source-footer-start > .commands > .action {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -44,25 +44,25 @@
   padding: 4px 6px;
 }
 
-.source-footer > .commands > button.action:hover {
+.source-footer > .source-footer-start > .commands > button.action:hover {
   background: var(--theme-toolbar-background-hover);
 }
 
-:root.theme-dark .source-footer > .commands > .action {
+:root.theme-dark .source-footer > .source-footer-start > .commands > .action {
   fill: var(--theme-body-color);
 }
 
-:root.theme-dark .source-footer > .commands > .action:hover {
+:root.theme-dark .source-footer > .source-footer-start > .commands > .action:hover {
   fill: var(--theme-selection-color);
 }
 
-.source-footer > .commands > div.loader {
+.source-footer > .source-footer-start > .commands > div.loader {
   vertical-align: top;
   width: 20px;
   margin: 0 4px;
 }
 
-.source-footer > .commands > .blackboxed > .img.blackBox {
+.source-footer > .source-footer-start > .commands > .blackboxed > .img.blackBox {
   background-color: var(--theme-icon-checked-color);
 }
 

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -34,6 +34,10 @@
   user-select: none;
 }
 
+.source-footer > .source-footer-start > .commands {
+  display: flex;
+}
+
 .source-footer > .source-footer-start > .commands > .action {
   display: flex;
   justify-content: center;

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -18,10 +18,15 @@
   box-sizing: border-box;
 }
 
-.source-footer .commands {
+.source-footer-start {
   display: flex;
   align-items: center;
   justify-self: start;
+}
+
+.source-footer-end {
+  display: flex;
+  margin-left: auto;
 }
 
 .source-footer .commands * {
@@ -65,7 +70,6 @@
 .source-footer .cursor-position {
   color: var(--theme-body-color);
   padding-right: 2.5px;
-  margin-left: auto;
 }
 
 .source-footer .mapped-source {

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -164,7 +164,6 @@ class SourceFooter extends PureComponent<Props, State> {
 
     return (
       <PaneToggleButton
-        position="end"
         key="toggle"
         collapsed={this.props.endPanelCollapsed}
         horizontal={this.props.horizontal}
@@ -242,10 +241,12 @@ class SourceFooter extends PureComponent<Props, State> {
   render() {
     return (
       <div className="source-footer">
-        {this.renderCommands()}
-        {this.renderSourceSummary()}
-        {this.renderCursorPosition()}
-        {this.renderToggleButton()}
+        <div className="source-footer-start">{this.renderCommands()}</div>
+        <div className="source-footer-end">
+          {this.renderSourceSummary()}
+          {this.renderCursorPosition()}
+          {this.renderToggleButton()}
+        </div>
       </div>
     );
   }

--- a/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
@@ -5,17 +5,24 @@ exports[`SourceFooter Component default case should render 1`] = `
   className="source-footer"
 >
   <div
-    className="cursor-position"
-    title="(Line 1, column 1)"
-  >
-    (1, 1)
-  </div>
-  <PaneToggleButton
-    collapsed={false}
-    horizontal={false}
-    key="toggle"
-    position="end"
+    className="source-footer-start"
   />
+  <div
+    className="source-footer-end"
+  >
+    <div
+      className="cursor-position"
+      title="(Line 1, column 1)"
+    >
+      (1, 1)
+    </div>
+    <PaneToggleButton
+      collapsed={false}
+      horizontal={false}
+      key="toggle"
+      position="start"
+    />
+  </div>
 </div>
 `;
 
@@ -24,16 +31,23 @@ exports[`SourceFooter Component move cursor should render new cursor position 1`
   className="source-footer"
 >
   <div
-    className="cursor-position"
-    title="(Line 6, column 11)"
-  >
-    (6, 11)
-  </div>
-  <PaneToggleButton
-    collapsed={false}
-    horizontal={false}
-    key="toggle"
-    position="end"
+    className="source-footer-start"
   />
+  <div
+    className="source-footer-end"
+  >
+    <div
+      className="cursor-position"
+      title="(Line 6, column 11)"
+    >
+      (6, 11)
+    </div>
+    <PaneToggleButton
+      collapsed={false}
+      horizontal={false}
+      key="toggle"
+      position="start"
+    />
+  </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #8064 



Here's the Pull Request Doc
https://firefox-dev.tools/debugger/docs/pull-requests.html

### Summary of Changes

* Split controls to the left and rest of icons on the right

### Test plan

* Check with different permutations of what can appear/not appear
For example the 'pretty print' button will show on minified source, the "from" information will show if there's a source map


### Screenshots/Videos (OPTIONAL)
![Screenshot 2019-03-24 at 22 45 00](https://user-images.githubusercontent.com/134585/54887104-16b4a600-4e87-11e9-899a-cb97c876bfff.png)
