### PR TITLE
Revert "ligned breakpoints and XHR breakpoints panes (#8094)"

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -6,24 +6,20 @@
   margin: 2px 3px;
 }
 
+.pane.breakpoints-list {
+  padding-bottom: 0.35em;
+}
+
 .breakpoints-list * {
   user-select: none;
 }
 
-.breakpoints-list {
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
 .breakpoints-list .breakpoint-heading {
   text-overflow: ellipsis;
+  overflow: hidden;
+  display: flex;
   width: 100%;
-  font-size: 12px;
-  line-height: 16px;
-}
-
-.breakpoint-heading:not(:first-child) {
-  margin-top: 2px;
+  align-items: center;
 }
 
 .breakpoints-list .breakpoint-heading .filename {
@@ -38,8 +34,10 @@
 
 .breakpoints-list .breakpoint-heading,
 .breakpoints-list .breakpoint {
+  font-size: 12px;
   color: var(--theme-content-color1);
   position: relative;
+  transition: all 0.25s ease;
   cursor: pointer;
 }
 
@@ -47,56 +45,53 @@
 .breakpoints-list .breakpoint,
 .breakpoints-exceptions,
 .breakpoints-exceptions-caught {
-  display: flex;
-  align-items: center;
-  overflow: hidden;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-inline-start: 16px;
-  padding-inline-end: 12px;
+  padding: 0.25em 1em;
 }
 
 .breakpoints-exceptions {
-  padding-bottom: 3px;
-  padding-top: 3px;
+  padding-bottom: 0.5em;
+  padding-top: 0.5em;
   user-select: none;
 }
 
+.breakpoints-list .breakpoint {
+  min-height: var(--breakpoint-expression-height);
+  overflow: hidden;
+}
+
 .breakpoints-exceptions-caught {
-  padding-bottom: 3px;
-  padding-top: 3px;
-  padding-inline-start: 36px;
+  padding: 0 1em 0.5em 3em;
+  margin-top: -0.25em;
 }
 
-.breakpoints-exceptions-options {
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.xhr-breakpoints-pane .breakpoints-exceptions-options {
-  border-bottom: 1px solid var(--theme-splitter-color);
+html[dir="rtl"] .breakpoints-exceptions-caught {
+  padding: 0 3em 0.5em 1em;
 }
 
 .breakpoints-exceptions-options:not(.empty) {
   border-bottom: 1px solid var(--theme-splitter-color);
+  margin-bottom: 3px;
 }
 
 .breakpoints-exceptions input,
 .breakpoints-exceptions-caught input {
   padding-inline-start: 2px;
-  margin-top: 0px;
-  margin-bottom: 0px;
   margin-inline-start: 0;
-  margin-inline-end: 2px;
   vertical-align: text-bottom;
 }
 
 .breakpoint-exceptions-label {
-  line-height: 14px;
+  padding-top: 2px;
+  padding-inline-start: 2px;
   padding-inline-end: 8px;
   cursor: default;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+.breakpoints-list .breakpoint,
+.breakpoints-exceptions,
+.breakpoints-exceptions-caught {
+  display: flex;
+  align-items: center;
 }
 
 html[dir="rtl"] .breakpoints-list .breakpoint,
@@ -133,17 +128,11 @@ html .breakpoints-list .breakpoint.paused {
   background-color: var(--search-overlays-semitransparent);
 }
 
-.breakpoint-line-close {
-  margin-inline-start: 4px;
-}
-
 .breakpoints-list .breakpoint .breakpoint-line {
   font-size: 11px;
   color: var(--theme-comment);
   min-width: 16px;
   text-align: end;
-  padding-top: 1px;
-  padding-bottom: 1px;
 }
 
 .breakpoints-list .breakpoint:hover .breakpoint-line,
@@ -156,24 +145,24 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoints-list .breakpoint-label {
+  max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
   display: inline-block;
+  padding-inline-end: 8px;
   cursor: pointer;
   flex-grow: 1;
   text-overflow: ellipsis;
   overflow: hidden;
+  padding-top: 2px;
   font-size: 11px;
 }
 
-.breakpoints-list .breakpoint-label span,
+.breakpoints-list .breakpoint-label,
 .breakpoint-line-close {
-  display: inline;
-  line-height: 14px;
+  line-height: 1.4em;
 }
 
 .breakpoint-checkbox {
-  margin-inline-start: 0px;
-  margin-top: 0px;
-  margin-bottom: 0px;
+  margin-inline-start: 0;
   vertical-align: text-bottom;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -77,49 +77,43 @@ class Breakpoints extends Component<Props> {
 
   renderBreakpoints() {
     const { breakpointSources, selectedSource } = this.props;
-    if (!breakpointSources.length) {
-      return null;
-    }
-
     const sources = [
       ...breakpointSources.map(({ source, breakpoints }) => source)
     ];
 
-    return (
-      <div className="pane breakpoints-list">
-        {breakpointSources.map(({ source, breakpoints, i }) => {
-          const path = getDisplayPath(source, sources);
-          const sortedBreakpoints = sortSelectedBreakpoints(
-            breakpoints,
-            selectedSource
-          );
+    return [
+      ...breakpointSources.map(({ source, breakpoints, i }) => {
+        const path = getDisplayPath(source, sources);
+        const sortedBreakpoints = sortSelectedBreakpoints(
+          breakpoints,
+          selectedSource
+        );
 
-          return [
-            <BreakpointHeading
+        return [
+          <BreakpointHeading
+            source={source}
+            sources={sources}
+            path={path}
+            key={source.url}
+          />,
+          ...sortedBreakpoints.map(breakpoint => (
+            <Breakpoint
+              breakpoint={breakpoint}
               source={source}
-              sources={sources}
-              path={path}
-              key={source.url}
-            />,
-            ...sortedBreakpoints.map(breakpoint => (
-              <Breakpoint
-                breakpoint={breakpoint}
-                source={source}
-                selectedSource={selectedSource}
-                key={makeBreakpointId(
-                  getSelectedLocation(breakpoint, selectedSource)
-                )}
-              />
-            ))
-          ];
-        })}
-      </div>
-    );
+              selectedSource={selectedSource}
+              key={makeBreakpointId(
+                getSelectedLocation(breakpoint, selectedSource)
+              )}
+            />
+          ))
+        ];
+      })
+    ];
   }
 
   render() {
     return (
-      <div>
+      <div className="pane breakpoints-list">
         {this.renderExceptionsOptions()}
         {this.renderBreakpoints()}
       </div>

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -44,7 +44,7 @@
 .expressions-list {
   /* TODO: add normalize */
   margin: 0;
-  padding: 4px 0px;
+  padding: 0;
 }
 
 .expression-input-container {

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -57,8 +57,3 @@
   width: 20em;
   overflow: auto;
 }
-
-.secondary-panes input[type="checkbox"] {
-  margin: 0;
-  margin-inline-end: 4px;
-}

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .xhr-input-container {
-  display: flex;
+  display: block;
   border: 1px solid transparent;
 }
 
@@ -19,25 +19,27 @@
   border: 1px solid red;
 }
 
+.xhr-container label {
+  display: flex;
+}
+
 .xhr-input-form {
   display: inline-flex;
   width: 100%;
-  padding-inline-start: 20px;
-  padding-inline-end: 12px;
+  padding: 0.5em 1em 0.5em 1em;
 }
 
 .xhr-checkbox {
   margin-inline-start: 0;
-  margin-inline-end: 4px;
 }
 
 .xhr-input-url {
   border: 1px;
-  padding: 3px 0px;
+  padding: 0em 0.6em 0em 0.6em;
   flex-grow: 1;
   background-color: var(--theme-sidebar-background);
-  font-size: inherit;
-  line-height: 14px;
+  font-size: 12px;
+  line-height: 18px;
   color: var(--theme-body-color);
 }
 
@@ -55,26 +57,26 @@
   border-left: 4px solid transparent;
   width: 100%;
   color: var(--theme-body-color);
-  padding-inline-start: 16px;
-  padding-inline-end: 12px;
+  padding: 0.25em 1em;
   background-color: var(--theme-body-background);
   display: flex;
   align-items: center;
   position: relative;
+  min-height: var(--breakpoint-expression-height);
 }
 
 :root.theme-light .xhr-container:hover {
-  background-color: var(--search-overlays-semitransparent);
+  background-color: var(--theme-selection-background-hover);
 }
 
 :root.theme-dark .xhr-container:hover {
-  background-color: var(--search-overlays-semitransparent);
+  background-color: var(--theme-selection-background-hover);
 }
 
 .xhr-label-method {
-  line-height: 14px;
+  padding: 0px 2px 0px 2px;
+  line-height: 15px;
   display: inline-block;
-  margin-inline-end: 2px;
 }
 
 .xhr-input-method {
@@ -94,18 +96,27 @@
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 0px 2px 0px 2px;
-  line-height: 14px;
+  line-height: 15px;
+  font-size: 11px;
 }
 
 .xhr-container label {
   flex-grow: 1;
   display: flex;
+  padding-inline-end: 36px;
   align-items: center;
   overflow-x: hidden;
 }
 
 .xhr-container__close-btn {
-  display: flex;
-  padding-top: 2px;
-  padding-bottom: 2px;
+  position: absolute;
+  top: calc(50% - 8px);
+}
+
+[dir="ltr"] .xhr-container__close-btn {
+  right: 12px;
+}
+
+[dir="rtl"] .xhr-container__close-btn {
+  left: 12px;
 }

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -74,7 +74,7 @@
 
 .accordion ._content {
   border-bottom: 1px solid var(--theme-splitter-color);
-  font-size: var(--theme-body-font-size);
+  font-size: 12px;
 }
 
 .accordion div:last-child ._content {

--- a/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 function openFirstBreakpointContextMenu(dbg) {
-  rightClickElement(dbg, "breakpointItem", 2);
+  rightClickElement(dbg, "breakpointItem", 3);
 }
 
 // Tests to see if we can trigger a breakpoint action via the context menu

--- a/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -144,7 +144,7 @@ add_task(async function() {
   is(bp.options.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, { hasCondition: true });
 
-  rightClickElement(dbg, "breakpointItem", 2);
+  rightClickElement(dbg, "breakpointItem", 3);
   info('select "remove condition"');
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.removeCondition);
   await waitForBreakpointWithoutCondition(dbg, "simple2", 5);

--- a/test/mochitest/browser_dbg-breakpoints.js
+++ b/test/mochitest/browser_dbg-breakpoints.js
@@ -1,6 +1,5 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 function toggleBreakpoint(dbg, index) {
   const bp = findAllElements(dbg, "breakpointItems")[index];
@@ -46,11 +45,8 @@ function subset(subArray, superArray) {
 
 function assertEmptyLines(dbg, lines) {
   const sourceId = dbg.selectors.getSelectedSourceId(dbg.store.getState());
-  const emptyLines = dbg.selectors.getEmptyLines(
-    dbg.store.getState(),
-    sourceId
-  );
-  ok(subset(lines, emptyLines), "empty lines should match");
+  const emptyLines = dbg.selectors.getEmptyLines(dbg.store.getState(), sourceId);
+  ok(subset(lines, emptyLines), 'empty lines should match');
 }
 
 // Test enabling and disabling a breakpoint using the check boxes
@@ -64,7 +60,7 @@ add_task(async function() {
 
   // Disable the first one
   await disableBreakpoint(dbg, 0);
-  const bp1 = findBreakpoint(dbg, "simple2", 3);
+  let bp1 = findBreakpoint(dbg, "simple2", 3);
   let bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
@@ -83,9 +79,9 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 3);
   await addBreakpoint(dbg, "simple2", 5);
 
-  assertEmptyLines(dbg, [1, 2]);
+  assertEmptyLines(dbg, [1,2]);
 
-  rightClickElement(dbg, "breakpointItem", 2);
+  rightClickElement(dbg, "breakpointItem", 3);
   const disableBreakpointDispatch = waitForDispatch(dbg, "DISABLE_BREAKPOINT");
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.disableSelf);
   await disableBreakpointDispatch;
@@ -95,7 +91,7 @@ add_task(async function() {
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 
-  rightClickElement(dbg, "breakpointItem", 2);
+  rightClickElement(dbg, "breakpointItem", 3);
   const enableBreakpointDispatch = waitForDispatch(dbg, "ENABLE_BREAKPOINT");
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.enableSelf);
   await enableBreakpointDispatch;


### PR DESCRIPTION
This reverts commit 6b4110eaf3638c3635b765b1b4781d8ca7b6cf7b.

I missed a few CSS issues with this PR that I've spotted later:

1.  There's too much space above and below the the expression and XHR inputs
2.  The breakpoint line-height seems small

<img width="512" alt="FewUIIssues" src="https://user-images.githubusercontent.com/46655/55003218-f9c2c480-4fa5-11e9-976e-cb00761d76c8.png">
