### PR TITLE
Enable dismissing keyboard shortcut info modal with “Escape” key

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -153,6 +153,8 @@ class App extends Component<Props, State> {
       quickOpenEnabled
     } = this.props;
 
+    const { shortcutsModalEnabled } = this.state;
+
     if (activeSearch) {
       e.preventDefault();
       closeActiveSearch();
@@ -161,6 +163,10 @@ class App extends Component<Props, State> {
     if (quickOpenEnabled) {
       e.preventDefault();
       closeQuickOpen();
+    }
+
+    if (shortcutsModalEnabled) {
+      this.toggleShortcutsModal();
     }
   };
 


### PR DESCRIPTION
Fixes #8144.

### Summary of Changes

In the original code, the `onEscape` function is only responsible for dismissing Quick Open and Active Search. It does not dismiss the Shortcuts Modal. 

I decided to remain consistent with the logic used for the “Cmd+/” shortcut to dismiss the Shortcuts Modal. Below is a code snippet showing how the `onCommandSlash` function dismisses the Shortcuts Modal.

[Code Snippet](https://github.com/firefox-devtools/debugger/blob/12ad6bed134b11f05ea30d0aa751edda49ee9cfe/src/components/App.js#L167-L169)

### Screenshots

**Demonstration of the Unwanted Behavior:**

![Unwanted_Shorcuts_Modal_Toggled_On_1](https://user-images.githubusercontent.com/35577323/55106291-8fd91680-509c-11e9-8c5b-c3f97ae1d9bc.jpg)
Above: The Shortcuts Modal button (orange arrow) or “Cmd+/” has been used to pull up the Shortcuts Modal.

![Unwanted_Shorcuts_Modal_Toggled_On_2](https://user-images.githubusercontent.com/35577323/55106310-9b2c4200-509c-11e9-9644-cafcfe528a51.png)
Above: “Escape” has been used to dismiss the Shortcuts Modal, but it is not dismissed. 

**Demonstration of the Changed Behavior:**
![Wanted_Shorcuts_Modal_Toggled_On_1](https://user-images.githubusercontent.com/35577323/55106337-a8e1c780-509c-11e9-9b9d-a7af78c297de.jpg)
Above: The Shortcuts Modal button (orange arrow) or “Cmd+/” has been used to pull up the Shortcuts Modal.

![Wanted_Shorcuts_Modal_Toggled_Off_2](https://user-images.githubusercontent.com/35577323/55106356-b72fe380-509c-11e9-82ca-c43298de36d7.png)

Above: After hitting “Escape,” the Shortcuts Modal has been dismissed.


### Test Plan

[x] “Escape” dismisses the Shortcuts Modal.
[x] “Escape” does not toggle the Shortcuts Modal on. This functionality is reserved for the “Cmd+/” shortcut.


