### PR TITLE
Render href attribute in String rep URLs.

### DIFF
--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -33,7 +33,8 @@ StringRep.propTypes = {
   object: PropTypes.object.isRequired,
   openLink: PropTypes.func,
   className: PropTypes.string,
-  title: PropTypes.string
+  title: PropTypes.string,
+  isInContentPage: PropTypes.bool
 };
 
 function StringRep(props) {
@@ -46,7 +47,8 @@ function StringRep(props) {
     escapeWhitespace = true,
     member,
     openLink,
-    title
+    title,
+    isInContentPage
   } = props;
 
   let text = object;
@@ -89,7 +91,12 @@ function StringRep(props) {
     if (containsURL(text)) {
       return span(
         config,
-        ...getLinkifiedElements(text, shouldCrop && cropLimit, openLink)
+        ...getLinkifiedElements(
+          text,
+          shouldCrop && cropLimit,
+          openLink,
+          isInContentPage
+        )
       );
     }
 
@@ -168,9 +175,11 @@ function maybeCropString(opts, text) {
  * @param {String} text: The actual string to linkify.
  * @param {Integer | null} cropLimit
  * @param {Function} openLink: Function handling the link opening.
+ * @param {Boolean} isInContentPage: pass true if the reps is rendered in
+ *                                   the content page (e.g. in JSONViewer).
  * @returns {Array<String|ReactElement>}
  */
-function getLinkifiedElements(text, cropLimit, openLink) {
+function getLinkifiedElements(text, cropLimit, openLink, isInContentPage) {
   const halfLimit = Math.ceil((cropLimit - ELLIPSIS.length) / 2);
   const startCropIndex = cropLimit ? halfLimit : null;
   const endCropIndex = cropLimit ? text.length - halfLimit : null;
@@ -210,6 +219,11 @@ function getLinkifiedElements(text, cropLimit, openLink) {
               className: "url",
               title: token,
               draggable: false,
+              // Because we don't want the link to be open in the current
+              // panel's frame, we only render the href attribute if `openLink`
+              // exists (so we can preventDefault) or if the reps will be
+              // displayed in content page (e.g. in the JSONViewer).
+              href: openLink || isInContentPage ? token : null,
               onClick: openLink
                 ? e => {
                     e.preventDefault();

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -38,10 +38,28 @@ describe("test String with URL", () => {
     const element = renderRep(url, { openLink, useQuotes: false });
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
+  });
+
+  it("renders a href when openLink isn't defined", () => {
+    const url = "http://example.com";
+    const element = renderRep(url, { useQuotes: false });
+    expect(element.text()).toEqual(url);
+    const link = element.find("a");
+    expect(link.prop("href")).toBe(null);
+    expect(link.prop("title")).toBe(url);
+  });
+
+  it("renders a href when no openLink but isInContentPage is true", () => {
+    const url = "http://example.com";
+    const element = renderRep(url, { useQuotes: false, isInContentPage: true });
+    expect(element.text()).toEqual(url);
+    const link = element.find("a");
+    expect(link.prop("href")).toBe(url);
+    expect(link.prop("title")).toBe(url);
   });
 
   it("renders a simple quoted URL", () => {
@@ -51,7 +69,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, { openLink, useQuotes: false });
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -64,7 +82,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, { openLink, useQuotes: false });
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -77,7 +95,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, { openLink, useQuotes: true });
     expect(element.text()).toEqual(`"\\"${url}\\""`);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -89,7 +107,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, { openLink, useQuotes: false });
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -101,7 +119,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, { openLink, useQuotes: false });
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -113,7 +131,7 @@ describe("test String with URL", () => {
     const element = renderRep(url, { openLink, useQuotes: false });
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -126,7 +144,7 @@ describe("test String with URL", () => {
     const element = renderRep(string, { openLink, useQuotes: false });
     expect(element.text()).toEqual(string);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -140,7 +158,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(string);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -157,12 +175,12 @@ describe("test String with URL", () => {
     expect(links).toHaveLength(2);
 
     const firstLink = links.at(0);
-    expect(firstLink.prop("href")).toBe(undefined);
+    expect(firstLink.prop("href")).toBe(url1);
     expect(firstLink.prop("title")).toBe(url1);
     testLinkClick(firstLink, openLink, url1);
 
     const secondLink = links.at(1);
-    expect(secondLink.prop("href")).toBe(undefined);
+    expect(secondLink.prop("href")).toBe(url2);
     expect(secondLink.prop("title")).toBe(url2);
     testLinkClick(secondLink, openLink, url2);
   });
@@ -188,7 +206,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("http://…ple.com");
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -205,7 +223,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -224,7 +242,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual(url);
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -241,11 +259,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://example.fr … http://example.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe(undefined);
+    expect(linkUs.prop("href")).toBe("http://example.us");
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -262,11 +280,11 @@ describe("test String with URL", () => {
       "- http://example.fr -…- http://example.us -"
     );
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe(undefined);
+    expect(linkUs.prop("href")).toBe("http://example.us");
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -281,11 +299,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://e…ample.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example-long.fr");
     expect(linkFr.prop("title")).toBe("http://example-long.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe(undefined);
+    expect(linkUs.prop("href")).toBe("http://example.us");
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -303,15 +321,15 @@ describe("test String with URL", () => {
       "- http://example-long.fr http:…xample.com http://example.us -"
     );
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example-long.fr");
     expect(linkFr.prop("title")).toBe("http://example-long.fr");
 
     const linkCom = element.find("a").at(1);
-    expect(linkCom.prop("href")).toBe(undefined);
+    expect(linkCom.prop("href")).toBe("http://example.com");
     expect(linkCom.prop("title")).toBe("http://example.com");
 
     const linkUs = element.find("a").at(2);
-    expect(linkUs.prop("href")).toBe(undefined);
+    expect(linkUs.prop("href")).toBe("http://example.us");
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -327,11 +345,11 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("- http://e…ample.us -");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
 
     const linkUs = element.find("a").at(1);
-    expect(linkUs.prop("href")).toBe(undefined);
+    expect(linkUs.prop("href")).toBe("http://example.us");
     expect(linkUs.prop("title")).toBe("http://example.us");
   });
 
@@ -346,7 +364,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("http://exa…cdefghijkl");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
   });
 
@@ -361,7 +379,7 @@ describe("test String with URL", () => {
 
     expect(element.text()).toEqual("abcdefghij…xample.fr ");
     const linkFr = element.find("a").at(0);
-    expect(linkFr.prop("href")).toBe(undefined);
+    expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
   });
 
@@ -403,7 +421,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`[ "${string}" ]`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -422,7 +440,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Array${length} [ "${string}" ]`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -437,7 +455,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Object { test: "${string}" }`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);
@@ -455,7 +473,7 @@ describe("test String with URL", () => {
     expect(element.text()).toEqual(`Object { test: "${string}" }`);
 
     const link = element.find("a");
-    expect(link.prop("href")).toBe(undefined);
+    expect(link.prop("href")).toBe(url);
     expect(link.prop("title")).toBe(url);
 
     testLinkClick(link, openLink, url);


### PR DESCRIPTION
Fixes #6108.

The attribute was removed because in some places
the link could be opened directly in the panel's
frame, which isn't good.
But this is breaking JSON Viewer links, and also
prevent some context menu entries to work in the
console (open link, copy link, …).

This patch adds the `href` attribute back, but only
if the reps are meant to be displayed in content
page, or if an `openLink` function is provided.
