### PR TITLE
Fix string linkification greediness.

### DIFF
--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -7,15 +7,15 @@ const PropTypes = require("prop-types");
 
 const {
   containsURL,
-  isURL,
   escapeString,
   getGripType,
   rawCropString,
   sanitizeString,
   wrapRender,
   isGrip,
-  tokenSplitRegex,
-  ELLIPSIS
+  ELLIPSIS,
+  uneatLastUrlCharsRegex,
+  urlRegex
 } = require("./rep-utils");
 
 const dom = require("react-dom-factories");
@@ -184,75 +184,75 @@ function getLinkifiedElements(text, cropLimit, openLink, isInContentPage) {
   const startCropIndex = cropLimit ? halfLimit : null;
   const endCropIndex = cropLimit ? text.length - halfLimit : null;
 
-  // As we walk through the tokens of the source string, we make sure to
-  // preserve the original whitespace that separated the tokens.
-  let currentIndex = 0;
   const items = [];
-  for (const token of text.split(tokenSplitRegex)) {
-    if (isURL(token)) {
-      // Let's grab all the non-url strings before the link.
-      const tokenStart = text.indexOf(token, currentIndex);
-      let nonUrlText = text.slice(currentIndex, tokenStart);
-      nonUrlText = getCroppedString(
-        nonUrlText,
-        currentIndex,
-        startCropIndex,
-        endCropIndex
-      );
-      if (nonUrlText) {
-        items.push(nonUrlText);
-      }
-
-      // Update the index to match the beginning of the token.
-      currentIndex = tokenStart;
-
-      const linkText = getCroppedString(
-        token,
-        currentIndex,
-        startCropIndex,
-        endCropIndex
-      );
-      if (linkText) {
-        items.push(
-          a(
-            {
-              className: "url",
-              title: token,
-              draggable: false,
-              // Because we don't want the link to be open in the current
-              // panel's frame, we only render the href attribute if `openLink`
-              // exists (so we can preventDefault) or if the reps will be
-              // displayed in content page (e.g. in the JSONViewer).
-              href: openLink || isInContentPage ? token : null,
-              onClick: openLink
-                ? e => {
-                    e.preventDefault();
-                    openLink(token, e);
-                  }
-                : null
-            },
-            linkText
-          )
-        );
-      }
-
-      currentIndex = tokenStart + token.length;
+  let currentIndex = 0;
+  let contentStart;
+  while (true) {
+    const url = urlRegex.exec(text);
+    // Pick the regexp with the earlier content; index will always be zero.
+    if (!url) {
+      break;
     }
+    contentStart = url.index + url[1].length;
+    if (contentStart > 0) {
+      const nonUrlText = text.substring(0, contentStart);
+      items.push(
+        getCroppedString(nonUrlText, currentIndex, startCropIndex, endCropIndex)
+      );
+    }
+
+    // There are some final characters for a URL that are much more likely
+    // to have been part of the enclosing text rather than the end of the
+    // URL.
+    let useUrl = url[2];
+    const uneat = uneatLastUrlCharsRegex.exec(useUrl);
+    if (uneat) {
+      useUrl = useUrl.substring(0, uneat.index);
+    }
+
+    currentIndex = currentIndex + contentStart;
+    const linkText = getCroppedString(
+      useUrl,
+      currentIndex,
+      startCropIndex,
+      endCropIndex
+    );
+
+    if (linkText) {
+      items.push(
+        a(
+          {
+            className: "url",
+            title: useUrl,
+            draggable: false,
+            // Because we don't want the link to be open in the current
+            // panel's frame, we only render the href attribute if `openLink`
+            // exists (so we can preventDefault) or if the reps will be
+            // displayed in content page (e.g. in the JSONViewer).
+            href: openLink || isInContentPage ? useUrl : null,
+            onClick: openLink
+              ? e => {
+                  e.preventDefault();
+                  openLink(useUrl, e);
+                }
+              : null
+          },
+          linkText
+        )
+      );
+    }
+
+    currentIndex = currentIndex + useUrl.length;
+    text = text.substring(url.index + url[1].length + useUrl.length);
   }
 
   // Clean up any non-URL text at the end of the source string,
   // i.e. not handled in the loop.
-  if (currentIndex !== text.length) {
-    let nonUrlText = text.slice(currentIndex, text.length);
+  if (text.length > 0) {
     if (currentIndex < endCropIndex) {
-      nonUrlText = getCroppedString(
-        nonUrlText,
-        currentIndex,
-        startCropIndex,
-        endCropIndex
-      );
+      text = getCroppedString(text, currentIndex, startCropIndex, endCropIndex);
     }
-    items.push(nonUrlText);
+    items.push(text);
   }
 
   return items;

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -335,7 +335,7 @@ describe("test String with URL", () => {
 
   it("renders successive cropped URLs with cropped elements between", () => {
     const text =
-      "- http://example.fr test http://example.fr test http://example.us -";
+      "- http://example.fr test http://example.es test http://example.us -";
     const openLink = jest.fn();
     const element = renderRep(text, {
       openLink,
@@ -381,6 +381,30 @@ describe("test String with URL", () => {
     const linkFr = element.find("a").at(0);
     expect(linkFr.prop("href")).toBe("http://example.fr");
     expect(linkFr.prop("title")).toBe("http://example.fr");
+  });
+
+  it("renders URLs without unrelated characters", () => {
+    const text =
+      "global(http://example.com) and local(http://example.us)" +
+      " and maybe https://example.fr, https://example.es?";
+    const openLink = jest.fn();
+    const element = renderRep(text, {
+      openLink,
+      useQuotes: false
+    });
+
+    expect(element.text()).toEqual(text);
+    const linkCom = element.find("a").at(0);
+    expect(linkCom.prop("href")).toBe("http://example.com");
+
+    const linkUs = element.find("a").at(1);
+    expect(linkUs.prop("href")).toBe("http://example.us");
+
+    const linkFr = element.find("a").at(2);
+    expect(linkFr.prop("href")).toBe("https://example.fr");
+
+    const linkEs = element.find("a").at(3);
+    expect(linkEs.prop("href")).toBe("https://example.es");
   });
 
   it("does not render a link if the URL has no scheme", () => {


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi\?id\=1204728

The String Rep linkification was too greedy and would
include unwanted character in the URL itself, although
it shouldn't (e.g.  would include the closing parens).

We switch to a regex solution, taking inspiration from
the mail app in Firefox OS (https://github.com/mozilla-b2g/gaia-email-libs-and-more/blob/convoy-status/js/clientapi/bodies/linkify.js).

Test cases are added to ensure this works as expected.
