### PR TITLE
[SourcesTree] Sort SourcesTree by url when files share same name

### DIFF
--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -48,7 +48,8 @@ function findOrCreateNode(
   part: string,
   index: number,
   url: Object,
-  debuggeeHost: ?string
+  debuggeeHost: ?string,
+  source: Source
 ): TreeDirectory {
   const addedPartIsFile = partIsFile(index, parts, url);
 
@@ -69,7 +70,11 @@ function findOrCreateNode(
 
   // if we have a naming conflict, we'll create a new node
   if (child.type === "source" || (!childIsFile && addedPartIsFile)) {
-    return createNodeInTree(part, path, subTree, childIndex);
+    const { index: insertIndex } = findNodeInContents(
+      subTree,
+      createTreeNodeMatcher(part, !addedPartIsFile, debuggeeHost, source, true)
+    );
+    return createNodeInTree(part, path, subTree, insertIndex);
   }
 
   // if there is no naming conflict, we can traverse into the child
@@ -83,7 +88,8 @@ function findOrCreateNode(
 function traverseTree(
   url: ParsedURL,
   tree: TreeDirectory,
-  debuggeeHost: ?string
+  debuggeeHost: ?string,
+  source: Source
 ): TreeNode {
   const parts = url.path.split("/").filter(p => p !== "");
   parts.unshift(url.group);
@@ -99,7 +105,8 @@ function traverseTree(
       part,
       index,
       url,
-      debuggeeHostIfRoot
+      debuggeeHostIfRoot,
+      source
     );
   }, tree);
 }
@@ -166,7 +173,7 @@ export function addToTree(
     return;
   }
 
-  const finalNode = traverseTree(url, tree, debuggeeHost);
+  const finalNode = traverseTree(url, tree, debuggeeHost, source);
 
   // $FlowIgnore
   finalNode.contents = addSourceToNode(finalNode, url, source);

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -70,6 +70,7 @@ function findOrCreateNode(
 
   // if we have a naming conflict, we'll create a new node
   if (child.type === "source" || (!childIsFile && addedPartIsFile)) {
+    // pass true to findNodeInContents to sort node by url
     const { index: insertIndex } = findNodeInContents(
       subTree,
       createTreeNodeMatcher(part, !addedPartIsFile, debuggeeHost, source, true)

--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -10,6 +10,8 @@ import { nodeHasChildren } from "./utils";
 
 import type { TreeNode } from "./types";
 
+import type { Source } from "../../types";
+
 /*
  * Gets domain from url (without www prefix)
  */
@@ -94,7 +96,9 @@ function createTreeNodeMatcherWithDebuggeeHost(
 function createTreeNodeMatcherWithNameAndOther(
   part: string,
   isDir: boolean,
-  debuggeeHost: ?string
+  debuggeeHost: ?string,
+  source?: Source,
+  hasSameName?: boolean
 ): FindNodeInContentsMatcher {
   return (node: TreeNode) => {
     if (node.name === IndexName) {
@@ -108,6 +112,10 @@ function createTreeNodeMatcherWithNameAndOther(
       return -1;
     } else if (!nodeIsDir && isDir) {
       return 1;
+    }
+
+    if (hasSameName && node.type === "source" && source) {
+      return node.contents.url.localeCompare(source.url);
     }
 
     return node.name.localeCompare(part);
@@ -125,7 +133,9 @@ function createTreeNodeMatcherWithNameAndOther(
 export function createTreeNodeMatcher(
   part: string,
   isDir: boolean,
-  debuggeeHost: ?string
+  debuggeeHost: ?string,
+  source?: Source,
+  hasSameName?: boolean
 ): FindNodeInContentsMatcher {
   if (part === IndexName) {
     // Specialied matcher, when we are looking for "(index)" position.
@@ -138,5 +148,5 @@ export function createTreeNodeMatcher(
   }
 
   // Rest of the cases, without mentioned above.
-  return createTreeNodeMatcherWithNameAndOther(part, isDir, debuggeeHost);
+  return createTreeNodeMatcherWithNameAndOther(part, isDir, debuggeeHost, source, hasSameName);
 }

--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -98,7 +98,7 @@ function createTreeNodeMatcherWithNameAndOther(
   isDir: boolean,
   debuggeeHost: ?string,
   source?: Source,
-  hasSameName?: boolean
+  sortByUrl?: boolean
 ): FindNodeInContentsMatcher {
   return (node: TreeNode) => {
     if (node.name === IndexName) {
@@ -113,8 +113,7 @@ function createTreeNodeMatcherWithNameAndOther(
     } else if (!nodeIsDir && isDir) {
       return 1;
     }
-
-    if (hasSameName && node.type === "source" && source) {
+    if (sortByUrl && node.type === "source" && source) {
       return node.contents.url.localeCompare(source.url);
     }
 
@@ -135,7 +134,7 @@ export function createTreeNodeMatcher(
   isDir: boolean,
   debuggeeHost: ?string,
   source?: Source,
-  hasSameName?: boolean
+  sortByUrl?: boolean
 ): FindNodeInContentsMatcher {
   if (part === IndexName) {
     // Specialied matcher, when we are looking for "(index)" position.
@@ -153,6 +152,6 @@ export function createTreeNodeMatcher(
     isDir,
     debuggeeHost,
     source,
-    hasSameName
+    sortByUrl
   );
 }

--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -148,5 +148,11 @@ export function createTreeNodeMatcher(
   }
 
   // Rest of the cases, without mentioned above.
-  return createTreeNodeMatcherWithNameAndOther(part, isDir, debuggeeHost, source, hasSameName);
+  return createTreeNodeMatcherWithNameAndOther(
+    part,
+    isDir,
+    debuggeeHost,
+    source,
+    hasSameName
+  );
 }

--- a/test/mochitest/browser_dbg-sources-querystring.js
+++ b/test/mochitest/browser_dbg-sources-querystring.js
@@ -27,9 +27,14 @@ add_task(async function() {
 
   const labels = [getLabel(dbg, 4), getLabel(dbg, 3)];
   is(
-    labels.includes("simple1.js?x=1") && labels.includes("simple1.js?x=2"),
-    true,
-    "simple1.js?x=1 and simple2.jsx=2 exist"
+    getLabel(dbg, 4),
+    "simple1.js?x=1",
+    "simple1.js?x=1 exists"
+  );
+  is(
+    getLabel(dbg, 3),
+    "simple1.js?x=2",
+    "simple1.js?x=2 exists"
   );
 
   const source = findSource(dbg, "simple1.js?x=1");

--- a/test/mochitest/browser_dbg-sources-querystring.js
+++ b/test/mochitest/browser_dbg-sources-querystring.js
@@ -27,12 +27,12 @@ add_task(async function() {
 
   const labels = [getLabel(dbg, 4), getLabel(dbg, 3)];
   is(
-    getLabel(dbg, 4),
+    getLabel(dbg, 3),
     "simple1.js?x=1",
     "simple1.js?x=1 exists"
   );
   is(
-    getLabel(dbg, 3),
+    getLabel(dbg, 4),
     "simple1.js?x=2",
     "simple1.js?x=2 exists"
   );


### PR DESCRIPTION
Fixes #7160 

### Summary of Changes

* Sort by entire url (including parameters) rather than name alone when files share same name
* Only sorts when naming conflicts exist

### Test Plan

* Modified mochitest (`doc-sources-querystring.html`) to test for sources in order

Example test plan:

1. Open https://fortunate-skunk.glitch.me/ 
2. Open debugger
3. See sources in order

Before/After
![image](https://user-images.githubusercontent.com/21224637/55358220-b673c480-5483-11e9-9354-50189d53b0bf.png)


