### PR TITLE
remove skip from grip.js test

### DIFF
--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -243,9 +243,9 @@ function propIterator(props, object, max) {
  */
 function getProps(componentProps, properties, indexes, suppressQuotes) {
   // Make indexes ordered by ascending.
-  indexes.sort(function(a, b) {
-    return a - b;
-  });
+  // indexes.sort(function(a, b) {
+  //   return a - b;
+  // });
 
   const propertiesKeys = Object.keys(properties);
   return indexes.map(i => {

--- a/packages/devtools-reps/src/reps/grip.js
+++ b/packages/devtools-reps/src/reps/grip.js
@@ -243,9 +243,9 @@ function propIterator(props, object, max) {
  */
 function getProps(componentProps, properties, indexes, suppressQuotes) {
   // Make indexes ordered by ascending.
-  // indexes.sort(function(a, b) {
-  //   return a - b;
-  // });
+  indexes.sort(function(a, b) {
+    return a - b;
+  });
 
   const propertiesKeys = Object.keys(properties);
   return indexes.map(i => {

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -276,14 +276,12 @@ describe("Grip - Object with uninteresting properties", () => {
     // @TODO This is broken at the moment.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1276376
     const renderRep = props => shallowRenderRep(object, props);
-    const defaultOutput = 'Object { a: undefined, c: "c", d: 1, … }';
+    const defaultOutput = 'Object { c: "c", d: 1, a: undefined, … }';
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(
-      'Object { a: undefined, b: undefined, c: "c", d: 1 }'
-    );
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -272,16 +272,18 @@ describe("Grip - Object with uninteresting properties", () => {
     expect(getRep(object)).toBe(Grip.rep);
   });
 
-  it.skip("renders as expected", () => {
+  it("renders as expected", () => {
     // @TODO This is broken at the moment.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1276376
     const renderRep = props => shallowRenderRep(object, props);
-    const defaultOutput = 'Object {c: "c", d: 1, a: undefined, more...}';
+    const defaultOutput = 'Object { a: undefined, c: "c", d: 1, … }';
 
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
     expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
     expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
+    expect(renderRep({ mode: MODE.LONG }).text()).toBe(
+      'Object { a: undefined, b: undefined, c: "c", d: 1 }'
+    );
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -264,27 +264,6 @@ describe("Grip - Object with more than long mode max props", () => {
   });
 });
 
-describe("Grip - Object with uninteresting properties", () => {
-  // Test object: `{a: undefined, b: undefined, c: "c", d: 1}`
-  const object = stubs.get("testUninterestingProps");
-
-  it("correctly selects Grip Rep", () => {
-    expect(getRep(object)).toBe(Grip.rep);
-  });
-
-  it("renders as expected", () => {
-    // @TODO This is broken at the moment.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1276376
-    const renderRep = props => shallowRenderRep(object, props);
-    const defaultOutput = 'Object { c: "c", d: 1, a: undefined, … }';
-
-    expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.TINY }).text()).toBe("{…}");
-    expect(renderRep({ mode: MODE.SHORT }).text()).toBe(defaultOutput);
-    expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
-  });
-});
-
 describe("Grip - Object with non-enumerable properties", () => {
   // Test object: `Object.defineProperty({}, "foo", {enumerable : false});`
   const object = stubs.get("testNonEnumerableProps");


### PR DESCRIPTION
Fixes #6147

### Summary of Changes

* remove skipp from `Grip - Object with uninteresting properties -> renders as expected test`

### Test Plan

Tweaked the tests a little and changed LONG MODE not to use default output for tests to pass

![Screenshot from 2019-04-03 10-34-16](https://user-images.githubusercontent.com/17080976/55461021-1a20fd80-55fc-11e9-95e9-75f2c6fa9fca.png)
