### PR TITLE
Replace outdated references to debugger.html

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,2 +1,2 @@
 ## Debugger Config
-`debugger.html` can be configured with multiple options by editing/creating `configs/local.json`. A sample of config file is [here](local.sample.json).
+`debugger` can be configured with multiple options by editing/creating `configs/local.json`. A sample of config file is [here](local.sample.json).

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -62,7 +62,7 @@ When you see that a package is included that you feel should not be in the bundl
 you can open the WebPack Analyzer and look.
 
 1.  go to [analyzer](http://webpack.github.io/analyse)
-2.  select open find the latest stats.json output `<debugger.html>/webpack-stats/stats-<sha>.json`
+2.  select open find the latest stats.json output `<debugger>/webpack-stats/stats-<sha>.json`
 
 The analyzer is a bit complicated, so here are some things to look for:
 

--- a/docs/community-team.md
+++ b/docs/community-team.md
@@ -1,6 +1,6 @@
 # :heart: Firefox Debugger Community Team :heart:
 
-_debugger.html_ community team members help shepherd the community. They are here to help mentor newcomers, review pull requests, and facilitate issue discussions.
+_debugger_ community team members help shepherd the community. They are here to help mentor newcomers, review pull requests, and facilitate issue discussions.
 
 They are genuinely friendly human beings, and together serve as a fantastic resource for anyone wishing to contribute to the Firefox Debugger.
 
@@ -54,7 +54,7 @@ Emeritus status honors those who have dedicated time and talent to the debugger 
 
 ### Joining the Team
 
-We welcome active contributors to join the _debugger.html_ team. Specifically, we are looking for contributors with:
+We welcome active contributors to join the _debugger_ team. Specifically, we are looking for contributors with:
 
 * Passion for the Firefox Debugger project
 * Interest in helping other contributors, and fostering community growth
@@ -62,7 +62,7 @@ We welcome active contributors to join the _debugger.html_ team. Specifically, w
 
 To apply, simply contact one of our staff or community team members via Slack or email, and we'll get right back to you.
 
-We embrace diversity, and invite people from any and all backgrounds to get involved in the _debugger.html_ project. We don't discriminate based on family status, gender, gender-identity, marital status, sexual orientation, sex, age, ability, race and/or ethnicity, national origin, socioeconomic status, religion, geographic location, or any other dimension of diversity.
+We embrace diversity, and invite people from any and all backgrounds to get involved in the _debugger_ project. We don't discriminate based on family status, gender, gender-identity, marital status, sexual orientation, sex, age, ability, race and/or ethnicity, national origin, socioeconomic status, religion, geographic location, or any other dimension of diversity.
 
 ### Review Periods
 

--- a/docs/debugger-react-redux-overview.md
+++ b/docs/debugger-react-redux-overview.md
@@ -7,12 +7,12 @@
 
 
 
-debugger.html
+debugger
 =============
 
-Debugger.html is an open source project that is built on top of React and Redux that functions as a standalone debugger for Firefox, Chrome and Node. This project is being created to provide a debugger that is stand-alone and does not require a specific browser tool to do debugging.
+*debugger* is an open source project that is built on top of React and Redux that functions as a standalone debugger for Firefox, Chrome and Node. This project is being created to provide a debugger that is stand-alone and does not require a specific browser tool to do debugging.
 
-This document gives a detailed view of the components, actions and reducers that make up the debugger.html project. Prior knowledge of React and Redux  is suggested.
+This document gives a detailed view of the components, actions and reducers that make up the *debugger* project. Prior knowledge of React and Redux  is suggested.
 
 React documentation can be found [here](https://facebook.github.io/react/docs/getting-started.html).
 Redux documentation can be found [here](http://redux.js.org/).
@@ -22,7 +22,7 @@ As with most documentation related to code, this document may be out of date. Th
 # Architecture
 
 
-Debugger.html is a React-Redux based application — the UI is constructed using React Components. the follow illustration provides a simplistic high level view:
+*debugger* is a React-Redux based application — the UI is constructed using React Components. the follow illustration provides a simplistic high level view:
 
 ![](https://docs.google.com/drawings/d/1JTDI-62CG29M37rpTGIDh70rOTuCmJf1VqxCKPe9zxM/pub?w=960&h=720)
 <!-- Link to Edit:(https://docs.google.com/drawings/d/1JTDI-62CG29M37rpTGIDh70rOTuCmJf1VqxCKPe9zxM/edit?usp=sharing) -->
@@ -32,7 +32,7 @@ global state object (housed in a Redux store) that some components have
 access to. Many components are not aware of this state but are passed in
 values to render using React properties.
 
-In the Debugger.html project we
+In the *debugger* project we
 also often use React’s setState to manage component local state. For
 example, storing the state of a tree in the sources view or using it in
 the App component to remember if the file search box is being displayed
@@ -62,11 +62,11 @@ actual DOM will be rendered.
 # Components
 
 
-debugger.html uses React [Components](https://github.com/firefox-devtools/debugger/tree/master/src/components) to render portions of the
+*debugger* uses React [Components](https://github.com/firefox-devtools/debugger/tree/master/src/components) to render portions of the
 application. Each component’s source code is located under the
 src/components folder. In this section we will cover how the
 presentation pieces fit together; later we will discuss
-how debugger.html uses Redux to wire up data to each of the components.
+how *debugger* uses Redux to wire up data to each of the components.
 
 The top-level component is the App component; it encapsulates all
 other components. Presented below is an overview of the component
@@ -113,7 +113,7 @@ The center portion of the application displays either the source editor or a fil
 
 * At the top of the editor is the SourceTabs component, which is responsible for rendering tabs for every open file and highlighting the tab of the file currently open.
 
-* The Editor component is responsible for rendering the text, gutters and breakpoints for the currently selected file.  Debugger.html uses the CodeMirror npm package to do the actual rendering. The Editor component manages calls to CodeMirror.
+* The Editor component is responsible for rendering the text, gutters and breakpoints for the currently selected file.  *debugger* uses the CodeMirror npm package to do the actual rendering. The Editor component manages calls to CodeMirror.
 
 * Any time a breakpoint is set, the Editor creates a dynamic component called Breakpoint. The Breakpoint component is contained in the EditorBreakpoint.js file. The BreakPoint component also makes calls to CodeMirror for actual rendering of the breakpoint within the editor.
 
@@ -144,7 +144,7 @@ The farthest right section of the application is handled by many components. At 
 
 # Component Data
 
-Some components in Debugger.html are aware of the Redux store; others are
+Some components in *debugger* are aware of the Redux store; others are
 not and are just rendering passed in properties. The Redux-aware
 components are connected to the Redux store using the <code>connect()</code> method, as illustrated by the following code:
 
@@ -202,7 +202,7 @@ The **async-requests** reducer creates an array that stores a unique
 sequence number for every promise being executed from an action.
 It removes the sequence number from the array when a specific promise
 resolves or rejects. The following image shows a snapshot of the
-debugger.html state with an active promise.
+*debugger* state with an active promise.
 
 ![](images/asynchreducer.png)
 
@@ -293,7 +293,7 @@ variable scope.
 call stack.
 
 * The <code>selectedFrame</code> object stores the call stack frame
-currently selected in the Debugger.html UI.
+currently selected in the *debugger* UI.
 
 * The loadedObjects object
 stores the currently selected and expanded variable in the scopes pane.
@@ -441,7 +441,7 @@ The tabs reducer handles the following action types:
 
 # Actions
 
-The [actions](https://github.com/firefox-devtools/debugger/tree/master/src/actions) in debugger.html are all located in the
+The [actions](https://github.com/firefox-devtools/debugger/tree/master/src/actions) in *debugger* are all located in the
 src/actions folder; there is an action file corresponding to
  each reducer, which is responsible for dispatching the
 proper event when the application state needs to be modified. In this
@@ -658,7 +658,7 @@ action file exports the following functions:
 
 -   <code>getTextForSources()</code> – This function takes a set of source files and
     calls <code>loadSourceText()</code> to load each file. Currently this function is
-    not used in debugger.html.
+    not used in *debugger*.
 
 ## tabs
 
@@ -668,7 +668,7 @@ file exports the following functions:
 
 -   <code>newTabs()</code> – This function is called from src/main.js and sets
     the action type to <code>ADD\_TABS</code>. The action is dispatched from the
-    src/main.js when debugger.html is loading and displaying
+    src/main.js when *debugger* is loading and displaying
     the main page or when starting to debug when a specific tab
     is selected.
 

--- a/docs/debugging-the-debugger.md
+++ b/docs/debugging-the-debugger.md
@@ -92,7 +92,7 @@ When the debugger pauses, the fun begins! Here's a [gif](http://g.recordit.co/qu
 
 Here's some example code that can help you get started:
 
-The file `debugger.html/src/components/SecondaryPanes/Frames/WhyPaused.js` renders the reason for the pause in the sidebar, and the file `/debugger.html/src/utils/pause/why.js` is used in several places to expose the current paused state.
+The file `debugger/src/components/SecondaryPanes/Frames/WhyPaused.js` renders the reason for the pause in the sidebar, and the file `/debugger/src/utils/pause/why.js` is used in several places to expose the current paused state.
 
 **WhyPaused.js** (Starts at line 42):
 

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -20,7 +20,7 @@ NPM installs the latest versions. We use [Yarn][yarn] because we want to make su
 
 ```bash
 git clone https://github.com/firefox-devtools/debugger.git
-cd debugger.html
+cd debugger
 yarn install
 ```
 
@@ -33,7 +33,7 @@ Yarn is still new; if you're experiencing any unusual errors with it, please lea
 Now that Firefox is open, let's start the development server. In a new terminal tab, run these commands:
 
 ```bash
-cd debugger.html
+cd debugger
 yarn start
 ```
 
@@ -82,12 +82,12 @@ This setup is for people on the DevTools team (and any of you DevTools wizards o
 ```bash
 npm i -g yarn
 git clone https://github.com/firefox-devtools/debugger.git
-cd debugger.html
+cd debugger
 yarn install
 # close Firefox if it's already running
 /Applications/Firefox.app/Contents/MacOS/firefox-bin --start-debugger-server 6080 -P development
 # create a new terminal tab
-cd debugger.html
+cd debugger
 yarn start
 ```
 

--- a/docs/lerna.md
+++ b/docs/lerna.md
@@ -14,4 +14,4 @@ This setup has several benefits:
 
 ### Why is lerna forked?
 
-Lerna is forked so that the top-level package (debugger.html) can be linked with the sub-packages. This feature will hopefully be merged into Lerna soon.
+Lerna is forked so that the top-level package (`debugger`) can be linked with the sub-packages. This feature will hopefully be merged into Lerna soon.

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -14,7 +14,7 @@ Helping to maintain a project is the best way to contribute to its overall healt
 
 We encourage the community to help make bugs actionable, make features available,
 and close stale issues. Triaging is one of the most important contributions a
-community member can make for a project's health. [Steve Klabnik's article][gardening] on how to be an "open source gardener" reflects our values here at _debugger.html_.
+community member can make for a project's health. [Steve Klabnik's article][gardening] on how to be an "open source gardener" reflects our values here at _debugger_.
 
 #### Making Bugs Actionable
 
@@ -48,7 +48,7 @@ Here's how you can help review each of these types of issues:
 
 ### Prioritizing Issues
 
-_debugger.html_ is a highly active repository. There are too many issues open in the project at any one time for us to be able to complete them all in a timely manner.
+_debugger_ is a highly active repository. There are too many issues open in the project at any one time for us to be able to complete them all in a timely manner.
 
 We try to prioritize the issues into three buckets: **current milestone**, **backlog**, and **icebox**.
 
@@ -88,7 +88,7 @@ When done well, the person whom you follow up on feels appreciated and supported
 
 When done poorly, the person whom you follow up on feels rushed, micromanaged and second-guessed. Contributors made to feel this way will often struggle to complete their work, and they will be reluctant to ask for help. 
 
-Here at _debugger.html_, it is important that follow-ups go smoothly, and that all contributors involved feel appreciated and well-supported. 
+Here at _debugger_, it is important that follow-ups go smoothly, and that all contributors involved feel appreciated and well-supported. 
 
 Here are a few good rules of thumb that will help you follow up on in-progress work in a structured, respectful way: 
 

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -2,7 +2,7 @@
 
 Mochitests is a test runner for integration (end-to-end) testing that allows us to test the debugger literally as a user would use it natively.
 
-It is different from other test runners (Jest, Mocha, Jasmine) because it simulates a real user interacting with your application. For debugger, we do this by building your own version of Firefox with your changes to debugger.html. This Firefox build and its debugger is what's tested by Mochitests, in the same way that a user interacting with the debugger would natively.
+It is different from other test runners (Jest, Mocha, Jasmine) because it simulates a real user interacting with your application. For debugger, we do this by building your own version of Firefox with your changes to *debugger*. This Firefox build and its debugger is what's tested by Mochitests, in the same way that a user interacting with the debugger would natively.
 
 If you've submitted a pull request to this project, you've already worked with Mochitests! TravisCI, which is one of the checks your PR has to pass, runs Mochitests every time you push a new commit to your PR.
 
@@ -31,7 +31,7 @@ Typically, tests would simulate a user's action flow through the debugger _(e.g.
 
 ### Mac ###
 
-Before starting, make sure you have the most updated versions of [Homebrew](https://brew.sh/) and [Python](https://www.python.org/downloads/). Afterwards, run the following from inside the main `debugger.html` folder:
+Before starting, make sure you have the most updated versions of [Homebrew](https://brew.sh/) and [Python](https://www.python.org/downloads/). Afterwards, run the following from inside the main `debugger` folder:
 ```
 brew install mercurial
 brew install autoconf@2.13 && brew unlink autoconf
@@ -52,7 +52,7 @@ Afterwards, you can open a unix-flavor shell by starting:
 C:\mozilla-build\start-shell.bat
 ```
 
-In the shell, navigate to the Debugger.html project folder. On your first setup, `./bin/prepare-mochitests-dev` clones Firefox's repository (`mozilla-central`). Downloading all of Firefox's source files may take ~30-60minutes depending on your internet connection.
+In the shell, navigate to the *debugger* project folder. On your first setup, `./bin/prepare-mochitests-dev` clones Firefox's repository (`mozilla-central`). Downloading all of Firefox's source files may take ~30-60minutes depending on your internet connection.
 
 After your initial setup, running `./bin/prepare-mochitests-dev` updates the cloned Firefox repository.
 
@@ -60,7 +60,7 @@ After your initial setup, running `./bin/prepare-mochitests-dev` updates the clo
 
 > NOTE: Make sure you have [Yarn](https://yarnpkg.com/) installed before proceeding with the following steps
 
-Every time you want to run your tests, the Firefox clone needs to be rebuilt with your updated local debugger.html. To do that, run the following:
+Every time you want to run your tests, the Firefox clone needs to be rebuilt with your updated local *debugger*. To do that, run the following:
 
 ```
 yarn copy
@@ -158,7 +158,7 @@ add_task(async function() {
 
 While this is a simple example, most of the Mochitests you will encounter follow the same process. What's important in writing them is to know clearly the actions you expect the user to do, how the debugger should behave in response to those actions, and insert assertions to test those behaviors.
 
-In this example, we use a few helper functions that you may not be familiar with yet. These helper functions are all in [`test/mochitest/helpers.js`](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js), and for the most part are just variants on concepts you probably already know. For example, `findElementWithSelector()` is simply a wrapper for `document.querySelector()` specifically for your debugger instance.
+In this example, we use a few helper functions that you may not be familiar with yet. These helper functions are all in [`test/mochitest/helpers.js`](https://github.com/firefox-devtools/debugger/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js), and for the most part are just variants on concepts you probably already know. For example, `findElementWithSelector()` is simply a wrapper for `document.querySelector()` specifically for your debugger instance.
 
 ## Debugging your tests
 While working on your tests, you might find that they're not running the way you expect them to. There are a few ways to figure out what exactly is happening and we will list them out here.
@@ -219,7 +219,7 @@ Note that these `debugger` statements are not limited to test code. They are als
 ## Test Writing Tips ##
 By now, you should have a good grasp of the basic concepts of testing with Mochitests.
 
-At this point, it's worth taking some time to become familiar with the helper methods in [helpers.js](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js). Below, we list some common patterns that come up while testing, and "best practices" for how to deal with them using the helper methods.
+At this point, it's worth taking some time to become familiar with the helper methods in [helpers.js](https://github.com/firefox-devtools/debugger/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js). Below, we list some common patterns that come up while testing, and "best practices" for how to deal with them using the helper methods.
 
 ### Waiting in a test
 It's common to want to wait for something to happen in a test. Generally we wait for one of two things to happen:
@@ -261,7 +261,7 @@ add_task(async function() {
 ### Finding DOM elements
 You can find elements defined in the debugger instance's DOM by using either:
 
-1. `findElement()` which takes an element name from the shared `selectors` object defined in [helpers.js](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js).
+1. `findElement()` which takes an element name from the shared `selectors` object defined in [helpers.js](https://github.com/firefox-devtools/debugger/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js).
 
 ```js
 add_task(async function() {
@@ -312,7 +312,7 @@ invokeInTab(dbg, "content.document.querySelector('.source-footer .prettyPrint').
 ```
 
 ### Using Debugger (DBG) helpers ###
-The `dbg` object returned by `initDebugger()` has several helpful properties, e.g., `actions`, `selectors`, `getState`, `store`, `toolbox`, `win`. [Click here](https://github.com/firefox-devtools/debugger.html/blob/7cdf5a1e99de51a551a5814f34ca8fb7506e06fb/docs/dbg.md) to learn more about these helpers.
+The `dbg` object returned by `initDebugger()` has several helpful properties, e.g., `actions`, `selectors`, `getState`, `store`, `toolbox`, `win`. [Click here](https://github.com/firefox-devtools/debugger/blob/7cdf5a1e99de51a551a5814f34ca8fb7506e06fb/docs/dbg.md) to learn more about these helpers.
 
 ## Adding New Test Files ##
 
@@ -325,17 +325,17 @@ Intermittents are when a test succeeds most the time (~95%) of the time, but not
 ### Browser Inconsistencies ###
 Sometimes the server is not as consistent as you would like. For example, reloading can sometimes cause sources to load out of order, or stepping too quickly can cause the debugger to enter a bad state.
 
-A memorable example of this type of inconsistency came when debugging [stepping behavior](https://github.com/firefox-devtools/debugger.html/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3). It turns out that 1% of the time the browser toolbox will step into an unexpected location. The solution is to loosen our expectations :)
+A memorable example of this type of inconsistency came when debugging [stepping behavior](https://github.com/firefox-devtools/debugger/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3). It turns out that 1% of the time the browser toolbox will step into an unexpected location. The solution is to loosen our expectations :)
 
 ### Missed Action ###
 Sometimes action "B" can fire before action "A" is done. This is a race condition that can be hard to track down. When you suspect this might happen, it is a good practice to start listening for "B" before you fire action "A".
 
-[Here's](https://github.com/firefox-devtools/debugger.html/commit/7b4762d9333108b15d81bc41e12182370c81e81c) an example where this happened with reloading.
+[Here's](https://github.com/firefox-devtools/debugger/commit/7b4762d9333108b15d81bc41e12182370c81e81c) an example where this happened with reloading.
 
 ### State Changes ###
 One common way tests start failing occurs when the Redux actions introduces a new asynchronous operation. A good way to safe guard your tests is to wait on state to have certain values.
 
-For example, a test that we fixed was [pretty printing](https://github.com/firefox-devtools/debugger.html/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12). The test initially waited for the "select source" action to fire, which wasn't predictable. Switching the test to wait for the formatted source to exist first simplified the test tremendously.
+For example, a test that we fixed was [pretty printing](https://github.com/firefox-devtools/debugger/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12). The test initially waited for the "select source" action to fire, which wasn't predictable. Switching the test to wait for the formatted source to exist first simplified the test tremendously.
 
 ## Videos ##
 

--- a/docs/most-common-issues.md
+++ b/docs/most-common-issues.md
@@ -53,7 +53,7 @@ If that fails you can re-clone the repo:
 ```bash
 rm -rf [yourpath]/debugger
 git clone https://github.com/firefox-devtools/debugger
-cd debugger.html
+cd debugger
 yarn install
 yarn start
 ```

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -231,7 +231,7 @@ There are three steps you need to follow in order to do this:
 
 1. Rebuild with SSH
 2. Copy the SSH command
-3. `cd debugger.html`
+3. `cd debugger`
 4. `jest src`
 
 ##### Rebuild with SSH

--- a/docs/remotely-debuggable-browsers.md
+++ b/docs/remotely-debuggable-browsers.md
@@ -146,7 +146,7 @@ $ "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --remote-debuggi
 
 ### Safari
 
-These are the instructions for getting the debugger.html project to connect to and debug Safari on various platforms. Please file issues or make pull requests for any errors you encounter.
+These are the instructions for getting the *debugger* project to connect to and debug Safari on various platforms. Please file issues or make pull requests for any errors you encounter.
 
 #### iOS Simulator (Mac only)
 
@@ -171,7 +171,7 @@ These are the instructions for getting the debugger.html project to connect to a
 ios_webkit_debug_proxy
 ```
 
-* Run the [debugger.html](https://github.com/firefox-devtools/debugger)
+* Run the [debugger](https://github.com/firefox-devtools/debugger)
   * `npm start`
 * Connect using the following URL
   * [http://localhost:8000/?ws=localhost:9222/devtools/page/1](http://localhost:8000/?ws=localhost:9222/devtools/page/1)

--- a/docs/running-as-firefox-panel.md
+++ b/docs/running-as-firefox-panel.md
@@ -41,7 +41,7 @@ The detailed instructions for setting up your environment to build Firefox for W
 C:\mozilla-build\start-shell.bat
 ```
 
-In the shell, navigate to the debugger.html project folder, and follow the Getting Started instructions as mentioned.
+In the shell, navigate to the *debugger* project folder, and follow the Getting Started instructions as mentioned.
 
 ## Running Nightly with the local debugger
 

--- a/packages/devtools-reps/README.md
+++ b/packages/devtools-reps/README.md
@@ -42,11 +42,11 @@ Supported types:
 
 ## Getting started
 
-You need to clone the debugger.html repository, then install dependencies, for which you'll need the [Yarn](https://yarnpkg.com/en/) tool:
+You need to clone the *debugger* repository, then install dependencies, for which you'll need the [Yarn](https://yarnpkg.com/en/) tool:
 
 ```
 git clone https://github.com/firefox-devtools/debugger.git
-cd debugger.html
+cd debugger
 yarn install
 ```
 


### PR DESCRIPTION
Replace all outdated references to `debugger.html` with references to `debugger`, [as discussed with](https://github.com/firefox-devtools/debugger/pull/8009#issuecomment-466031447) @jasonLaster in PR #8009. 

Fixes N/A. 

### Summary of Changes

* Replace all instances of *debugger.html* with *debugger* (14 files changed total)
* Add simple formatting (bolding, code formatting, etc.) in limited cases, in order to avoid confusing the name of the repository (*debugger*) with the regular noun "debugger"