### PR TITLE
Changed gap placement on popover orientation-right

### DIFF
--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -8,8 +8,8 @@
 }
 
 .popover.orientation-right {
-	display: flex;
-	flex-direction: row;
+  display: flex;
+  flex-direction: row;
 }
 
 .popover.orientation-right .gap {

--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -7,7 +7,16 @@
   z-index: 100;
 }
 
-.popover .gap {
+.popover.orientation-right {
+	display: flex;
+	flex-direction: row;
+}
+
+.popover.orientation-right .gap {
+  padding-left: 5px;
+}
+
+.popover:not(.orientation-right) .gap {
   height: 5px;
   padding-top: 5px;
 }

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -74,7 +74,7 @@ class Popover extends Component<Props, State> {
     const estimatedRight = estimatedLeft + popover.width;
     const isOverflowingRight = estimatedRight > editor.right;
     if (orientation === "right") {
-      return target.left + target.width + 10;
+      return target.left + target.width + 5;
     }
     if (isOverflowingRight) {
       const adjustedLeft = editor.right - popover.width - 8;
@@ -221,7 +221,7 @@ class Popover extends Component<Props, State> {
     } else if (orientation === "down") {
       Object.assign(arrowProps, { orientation: "up", top: -7, left });
     } else {
-      Object.assign(arrowProps, { orientation: "left", top, left: -14 });
+      Object.assign(arrowProps, { orientation: "left", top, left: -9 });
     }
 
     return <BracketArrow {...arrowProps} />;

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -30,13 +30,13 @@ exports[`Popover mount popover 1`] = `
     onMouseLeave={[MockFunction]}
     style={
       Object {
-        "left": 510,
+        "left": 505,
         "top": 250,
       }
     }
   >
     <BracketArrow
-      left={-14}
+      left={-9}
       orientation="left"
       top={-202}
     >
@@ -45,7 +45,7 @@ exports[`Popover mount popover 1`] = `
         style={
           Object {
             "bottom": undefined,
-            "left": -14,
+            "left": -9,
             "top": -202,
           }
         }
@@ -160,13 +160,13 @@ exports[`Popover render 1`] = `
     onMouseLeave={[MockFunction]}
     style={
       Object {
-        "left": 510,
+        "left": 505,
         "top": 250,
       }
     }
   >
     <BracketArrow
-      left={-14}
+      left={-9}
       orientation="left"
       top={-202}
     >
@@ -175,7 +175,7 @@ exports[`Popover render 1`] = `
         style={
           Object {
             "bottom": undefined,
-            "left": -14,
+            "left": -9,
             "top": -202,
           }
         }


### PR DESCRIPTION
Fixes #8107 

### Summary of Changes

In the unchanged code, the gap is placed above the popover if the orientation is right.

I decided to use `flex-direction: row` in the popover.css file in order to change the placement of the gap, from above the popover to the left.  I then had to make some minor adjustments to the `calculateLeft` function and the `getPopoverArrow` function in the popover.js file to accommodate the changes made.

### Screenshots

**Gap placement before change:**
![image](https://user-images.githubusercontent.com/26233701/56295206-6854f700-60fa-11e9-8e14-4173edfb3006.png)

**Gap placement after change:**
![image](https://user-images.githubusercontent.com/26233701/56295281-86baf280-60fa-11e9-9721-bb0f5641da98.png)

### Test Plan

- [x] Decrease the width of the editor pane or increase zoom if necessary
- [x] Set a breakpoint
- [x] Scroll until breakpoint is approximately in the middle of the editor pane
- [x] Trigger breakpoint
- [x] Hover over a token
