### PR TITLE
Use dedicated accesskey for editing log points (#8196)

### DIFF
--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -88,7 +88,7 @@ export const editLogPointItem = (
 ) => ({
   id: "node-menu-edit-log-point",
   label: L10N.getStr("editor.editLogPoint"),
-  accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
+  accesskey: L10N.getStr("editor.editLogPoint.accesskey"),
   disabled: false,
   click: () => breakpointActions.openConditionalPanel(location, true),
   accelerator: L10N.getStr("toggleCondPanel.logPoint.key")

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -232,7 +232,7 @@ export default function showContextMenu(props: Props) {
   const editLogPointItem = {
     id: "node-menu-edit-log-point",
     label: L10N.getStr("editor.editLogPoint"),
-    accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
+    accesskey: L10N.getStr("editor.editLogPoint.accesskey"),
     disabled: false,
     click: () => openConditionalPanel(selectedLocation, true),
     accelerator: L10N.getStr("toggleCondPanel.logPoint.key")


### PR DESCRIPTION
Fixes #8196

Here's the Pull Request Doc
https://firefox-dev.tools/debugger/docs/pull-requests.html

### Summary of Changes

* switches context menus to use existing accesskey for 'Edit Log' action

### Test Plan

Not tested.

Steps to test:
1. Set a breakpoint on a line.
2. In the right sidebar, right click the breakpoint.
3. From the menu, choose 'Add log'. (Accesskey: l)
4. Enter something for the log point
5. Right click again in the sidebar. Accesskey should be `E`.