### PR TITLE
Improve performance of "Go to file"

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -391,8 +391,6 @@ export class QuickOpenModal extends Component<Props, State> {
     const items = this.highlightMatching(query, results || []);
     const expanded = !!items && items.length > 0;
 
-    console.log('results', results);
-
     return (
       <Modal in={enabled} handleClose={this.closeModal}>
         <SearchInput

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -160,8 +160,8 @@ export class QuickOpenModal extends Component<Props, State> {
   showTopSources = () => {
     const { tabs, sources } = this.props;
     if (tabs.length > 0) {
-      const tabUrls = tabs.map((tab: Tab) => tab.url);
-      this.setResults(sources.filter(source => tabUrls.includes(source.url)));
+      const tabUrls = new Set(tabs.map((tab: Tab) => tab.url));
+      this.setResults(sources.filter(source => tabUrls.has(source.url)));
     } else {
       this.setResults(sources);
     }
@@ -422,16 +422,18 @@ export class QuickOpenModal extends Component<Props, State> {
 /* istanbul ignore next: ignoring testing of redux connection stuff */
 function mapStateToProps(state) {
   const selectedSource = getSelectedSource(state);
+  const tabs = getTabs(state);
+  const tabUrls = new Set(tabs.map((tab: Tab) => tab.url));
 
   return {
     enabled: getQuickOpenEnabled(state),
-    sources: formatSources(getDisplayedSourcesList(state), getTabs(state)),
+    sources: formatSources(getDisplayedSourcesList(state), tabUrls),
     selectedSource,
     symbols: formatSymbols(getSymbols(state, selectedSource)),
     symbolsLoading: isSymbolsLoading(state, selectedSource),
     query: getQuickOpenQuery(state),
     searchType: getQuickOpenType(state),
-    tabs: getTabs(state)
+    tabs
   };
 }
 

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -440,7 +440,9 @@ function mapStateToProps(state) {
     query: getQuickOpenQuery(state),
     searchType: getQuickOpenType(state),
     tabs,
-    computeSources: (tabUrls: Set<$PropertyType<Tab, "url">>): Array<Object> => {
+    computeSources: (
+      tabUrls: Set<$PropertyType<Tab, "url">>
+    ): Array<Object> => {
       return formatSources(getDisplayedSourcesList(state), tabUrls);
     }
   };

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -7,10 +7,14 @@
 
 import React from "react";
 import { shallow, mount } from "enzyme";
+import lodash from "lodash";
 import { QuickOpenModal } from "../QuickOpenModal";
 
 jest.mock("fuzzaldrin-plus");
-jest.useFakeTimers();
+jest.unmock("lodash");
+
+// $FlowIgnore
+lodash.debounce = jest.fn(fn => fn);
 
 import { filter } from "fuzzaldrin-plus";
 
@@ -70,13 +74,11 @@ describe("QuickOpenModal", () => {
 
   test("Renders when enabled", () => {
     const { wrapper } = generateModal({ enabled: true });
-    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
   test("Basic render with mount", () => {
     const { wrapper } = generateModal({ enabled: true }, "mount");
-    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -93,7 +95,6 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
-    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -120,7 +121,6 @@ describe("QuickOpenModal", () => {
       },
       "shallow"
     );
-    jest.runAllTimers();
     expect(wrapper.state("results")).toEqual([{ url: "mozilla.com" }]);
   });
 
@@ -156,7 +156,6 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
-    jest.runAllTimers();
     expect(wrapper.find("ResultList")).toHaveLength(1);
     expect(wrapper.find("li")).toHaveLength(1);
   });
@@ -190,17 +189,14 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
-    jest.runAllTimers();
     expect(wrapper.find("ResultList")).toHaveLength(1);
     expect(wrapper.find("li")).toHaveLength(3);
   });
 
   test("updateResults on enable", () => {
     const { wrapper } = generateModal({}, "mount");
-    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
     wrapper.setProps({ enabled: true });
-    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -216,7 +212,6 @@ describe("QuickOpenModal", () => {
       "mount"
     );
     wrapper.find("input").simulate("change", { target: { value: "somefil" } });
-    jest.runAllTimers();
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
       maxResults: 100
@@ -238,7 +233,6 @@ describe("QuickOpenModal", () => {
     wrapper
       .find("input")
       .simulate("change", { target: { value: "somefil:33" } });
-    jest.runAllTimers();
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
       maxResults: 100
@@ -265,8 +259,6 @@ describe("QuickOpenModal", () => {
       wrapper
         .find("input")
         .simulate("change", { target: { value: "@someFunc" } });
-
-      jest.runAllTimers();
 
       expect(filter).toHaveBeenCalledWith([], "someFunc", {
         key: "value",
@@ -799,7 +791,7 @@ describe("QuickOpenModal", () => {
         },
         "mount"
       );
-      jest.runAllTimers();
+
       expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -23,7 +23,7 @@ function generateModal(propOverrides, renderType = "shallow") {
     enabled: false,
     query: "",
     searchType: "sources",
-    computeSources: () => [],
+    displayedSources: [],
     tabs: [],
     selectSpecificLocation: jest.fn(),
     setQuickOpenQuery: jest.fn(),
@@ -116,12 +116,24 @@ describe("QuickOpenModal", () => {
       {
         enabled: true,
         query: "",
-        computeSources: () => [{ url: "mozilla.com" }],
+        displayedSources: [
+          // $FlowIgnore
+          { url: "mozilla.com", relativeUrl: true }
+        ],
         tabs: [generateTab("mozilla.com")]
       },
       "shallow"
     );
-    expect(wrapper.state("results")).toEqual([{ url: "mozilla.com" }]);
+    expect(wrapper.state("results")).toEqual([
+      {
+        id: undefined,
+        icon: "tab result-item-icon",
+        subtitle: "true",
+        title: "mozilla.com",
+        url: "mozilla.com",
+        value: "true"
+      }
+    ]);
   });
 
   describe("shows loading", () => {

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -10,6 +10,7 @@ import { shallow, mount } from "enzyme";
 import { QuickOpenModal } from "../QuickOpenModal";
 
 jest.mock("fuzzaldrin-plus");
+jest.useFakeTimers();
 
 import { filter } from "fuzzaldrin-plus";
 
@@ -18,7 +19,7 @@ function generateModal(propOverrides, renderType = "shallow") {
     enabled: false,
     query: "",
     searchType: "sources",
-    sources: [],
+    computeSources: () => [],
     tabs: [],
     selectSpecificLocation: jest.fn(),
     setQuickOpenQuery: jest.fn(),
@@ -69,11 +70,13 @@ describe("QuickOpenModal", () => {
 
   test("Renders when enabled", () => {
     const { wrapper } = generateModal({ enabled: true });
+    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
   test("Basic render with mount", () => {
     const { wrapper } = generateModal({ enabled: true }, "mount");
+    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -90,6 +93,7 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
+    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -111,11 +115,12 @@ describe("QuickOpenModal", () => {
       {
         enabled: true,
         query: "",
-        sources: [{ url: "mozilla.com" }],
+        computeSources: () => [{ url: "mozilla.com" }],
         tabs: [generateTab("mozilla.com")]
       },
       "shallow"
     );
+    jest.runAllTimers();
     expect(wrapper.state("results")).toEqual([{ url: "mozilla.com" }]);
   });
 
@@ -151,6 +156,7 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
+    jest.runAllTimers();
     expect(wrapper.find("ResultList")).toHaveLength(1);
     expect(wrapper.find("li")).toHaveLength(1);
   });
@@ -184,14 +190,17 @@ describe("QuickOpenModal", () => {
       },
       "mount"
     );
+    jest.runAllTimers();
     expect(wrapper.find("ResultList")).toHaveLength(1);
     expect(wrapper.find("li")).toHaveLength(3);
   });
 
   test("updateResults on enable", () => {
     const { wrapper } = generateModal({}, "mount");
+    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
     wrapper.setProps({ enabled: true });
+    jest.runAllTimers();
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -207,6 +216,7 @@ describe("QuickOpenModal", () => {
       "mount"
     );
     wrapper.find("input").simulate("change", { target: { value: "somefil" } });
+    jest.runAllTimers();
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
       maxResults: 100
@@ -228,6 +238,7 @@ describe("QuickOpenModal", () => {
     wrapper
       .find("input")
       .simulate("change", { target: { value: "somefil:33" } });
+    jest.runAllTimers();
     expect(filter).toHaveBeenCalledWith([], "somefil", {
       key: "value",
       maxResults: 100
@@ -254,6 +265,8 @@ describe("QuickOpenModal", () => {
       wrapper
         .find("input")
         .simulate("change", { target: { value: "@someFunc" } });
+
+      jest.runAllTimers();
 
       expect(filter).toHaveBeenCalledWith([], "someFunc", {
         key: "value",
@@ -786,6 +799,7 @@ describe("QuickOpenModal", () => {
         },
         "mount"
       );
+      jest.runAllTimers();
       expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
@@ -4,7 +4,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -132,7 +132,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -244,7 +244,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -406,7 +406,7 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -523,7 +523,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -682,7 +682,7 @@ exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -798,7 +798,7 @@ exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -925,7 +925,7 @@ exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] =
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1041,7 +1041,7 @@ exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1185,7 +1185,7 @@ exports[`QuickOpenModal updateResults on enable 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={false}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1210,7 +1210,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
-  computeSources={[Function]}
+  displayedSources={Array []}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}

--- a/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
@@ -4,6 +4,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -12,7 +13,6 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -132,6 +132,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -140,7 +141,6 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -244,6 +244,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -252,7 +253,6 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -406,6 +406,7 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -414,7 +415,6 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -523,6 +523,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -531,7 +532,6 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -682,6 +682,7 @@ exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -690,7 +691,6 @@ exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -798,6 +798,7 @@ exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -806,7 +807,6 @@ exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -925,6 +925,7 @@ exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] =
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -933,7 +934,6 @@ exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] =
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -1041,6 +1041,7 @@ exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1049,7 +1050,6 @@ exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -1185,6 +1185,7 @@ exports[`QuickOpenModal updateResults on enable 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={false}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1193,7 +1194,6 @@ exports[`QuickOpenModal updateResults on enable 1`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],
@@ -1210,6 +1210,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
 <QuickOpenModal
   clearHighlightLineRange={[MockFunction]}
   closeQuickOpen={[MockFunction]}
+  computeSources={[Function]}
   enabled={true}
   highlightLineRange={[MockFunction]}
   isOriginal={false}
@@ -1218,7 +1219,6 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
   selectSpecificLocation={[MockFunction]}
   setQuickOpenQuery={[MockFunction]}
   shortcutsModalEnabled={false}
-  sources={Array []}
   symbols={
     Object {
       "functions": Array [],

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -14,7 +14,7 @@ import {
 import type { Location as BabelLocation } from "@babel/types";
 import type { Symbols } from "../reducers/ast";
 import type { QuickOpenType } from "../reducers/quick-open";
-import type { TabList } from "../reducers/tabs";
+import type { Tab } from "../reducers/tabs";
 import type { Source } from "../types";
 import type {
   SymbolDeclaration,
@@ -58,7 +58,10 @@ export function parseLineColumn(query: string) {
   }
 }
 
-export function formatSourcesForList(source: Source, tabs: TabList) {
+export function formatSourcesForList(
+  source: Source,
+  tabUrls: Set<$PropertyType<Tab, "url">>
+) {
   const title = getFilename(source);
   const relativeUrlWithQuery = `${source.relativeUrl}${getSourceQueryString(
     source
@@ -68,7 +71,7 @@ export function formatSourcesForList(source: Source, tabs: TabList) {
     value: relativeUrlWithQuery,
     title,
     subtitle: relativeUrlWithQuery,
-    icon: tabs.some(tab => tab.url == source.url)
+    icon: tabUrls.has(source.url)
       ? "tab result-item-icon"
       : classnames(getSourceClassnames(source), "result-item-icon"),
     id: source.id,
@@ -136,9 +139,9 @@ export function formatShortcutResults(): Array<QuickOpenResult> {
 
 export function formatSources(
   sources: Source[],
-  tabs: TabList
+  tabUrls: Set<$PropertyType<Tab, "url">>
 ): Array<QuickOpenResult> {
   return sources
     .filter(source => !!source.relativeUrl && !isPretty(source))
-    .map(source => formatSourcesForList(source, tabs));
+    .map(source => formatSourcesForList(source, tabUrls));
 }

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -139,7 +139,6 @@ export function formatSources(
   tabs: TabList
 ): Array<QuickOpenResult> {
   return sources
-    .filter(source => !isPretty(source))
-    .filter(({ relativeUrl }) => !!relativeUrl)
+    .filter(source => !!source.relativeUrl && !isPretty(source))
     .map(source => formatSourcesForList(source, tabs));
 }

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -42,12 +42,16 @@ function chromeScrollList(elem: Element, index: number): void {
     return;
   }
 
-  const resultsHeight: number = resultsEl.clientHeight;
-  const itemHeight: number = resultsEl.children[0].clientHeight;
-  const numVisible: number = resultsHeight / itemHeight;
-  const positionsToScroll: number = index - numVisible + 1;
-  const itemOffset: number = resultsHeight % itemHeight;
-  const scroll: number = positionsToScroll * (itemHeight + 2) + itemOffset;
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      const resultsHeight: number = resultsEl.clientHeight;
+      const itemHeight: number = resultsEl.children[0].clientHeight;
+      const numVisible: number = resultsHeight / itemHeight;
+      const positionsToScroll: number = index - numVisible + 1;
+      const itemOffset: number = resultsHeight % itemHeight;
+      const scroll: number = positionsToScroll * (itemHeight + 2) + itemOffset;
 
-  resultsEl.scrollTop = Math.max(0, scroll);
+      resultsEl.scrollTop = Math.max(0, scroll);
+    });
+  });
 }

--- a/test/mochitest/browser_dbg-quick-open.js
+++ b/test/mochitest/browser_dbg-quick-open.js
@@ -51,10 +51,9 @@ async function quickOpen(dbg, query, shortcut = "quickOpen") {
   pressKey(dbg, shortcut);
   assertEnabled(dbg);
 
-  if (query !== "") {
-    type(dbg, query);
-    await waitForTime(150);
-  }
+  query !== "" && type(dbg, query);
+
+  await waitForTime(150);
 }
 
 function findResultEl(dbg, index = 1) {
@@ -109,6 +108,7 @@ add_task(async function() {
   is(resultCount(dbg), 2, "two function results");
 
   type(dbg, "@x");
+  await waitForTime(150);
   is(resultCount(dbg), 0, "no functions with 'x' in name");
 
   pressKey(dbg, "Escape");

--- a/test/mochitest/browser_dbg-quick-open.js
+++ b/test/mochitest/browser_dbg-quick-open.js
@@ -47,10 +47,14 @@ function resultCount(dbg) {
   return findAllElements(dbg, "resultItems").length;
 }
 
-function quickOpen(dbg, query, shortcut = "quickOpen") {
+async function quickOpen(dbg, query, shortcut = "quickOpen") {
   pressKey(dbg, shortcut);
   assertEnabled(dbg);
-  query !== "" && type(dbg, query);
+
+  if (query !== "") {
+    type(dbg, query);
+    await waitForTime(150);
+  }
 }
 
 function findResultEl(dbg, index = 1) {
@@ -67,41 +71,41 @@ add_task(async function() {
   const dbg = await initDebugger("doc-script-switching.html");
 
   info("test opening and closing");
-  quickOpen(dbg, "");
+  await quickOpen(dbg, "");
   pressKey(dbg, "Escape");
   assertDisabled(dbg);
 
   info("Testing the number of results for source search");
-  quickOpen(dbg, "sw");
+  await quickOpen(dbg, "sw");
   is(resultCount(dbg), 2, "two file results");
   pressKey(dbg, "Escape");
 
   info("Testing source search and check to see if source is selected");
   await waitForSource(dbg, "switching-01");
-  quickOpen(dbg, "sw1");
+  await quickOpen(dbg, "sw1");
   is(resultCount(dbg), 1, "one file results");
   pressKey(dbg, "Enter");
   await waitForSelectedSource(dbg, "switching-01");
 
   info("Test that results show tab icons");
-  quickOpen(dbg, "sw1");
+  await quickOpen(dbg, "sw1");
   await assertResultIsTab(dbg, 1);
   pressKey(dbg, "Tab");
 
   info("Testing arrow keys in source search and check to see if source is selected");
-  quickOpen(dbg, "sw2");
+  await quickOpen(dbg, "sw2");
   is(resultCount(dbg), 1, "one file results");
   pressKey(dbg, "Down");
   pressKey(dbg, "Enter");
   await waitForSelectedSource(dbg, "switching-02");
 
   info("Testing tab closes the search");
-  quickOpen(dbg, "sw");
+  await quickOpen(dbg, "sw");
   pressKey(dbg, "Tab");
   assertDisabled(dbg);
 
   info("Testing function search");
-  quickOpen(dbg, "", "quickOpenFunc");
+  await quickOpen(dbg, "", "quickOpenFunc");
   is(resultCount(dbg), 2, "two function results");
 
   type(dbg, "@x");
@@ -113,15 +117,14 @@ add_task(async function() {
   info("Testing goto line:column");
   assertLine(dbg, 0);
   assertColumn(dbg, null);
-  quickOpen(dbg, ":7:12");
+  await quickOpen(dbg, ":7:12");
   pressKey(dbg, "Enter");
   assertLine(dbg, 7);
   assertColumn(dbg, 12);
 
   info("Testing gotoSource");
-  quickOpen(dbg, "sw1:5");
+  await quickOpen(dbg, "sw1:5");
   pressKey(dbg, "Enter");
-  await waitForTime(150);
   await waitForSelectedSource(dbg, "switching-01");
   assertLine(dbg, 5);
 });

--- a/test/mochitest/browser_dbg-quick-open.js
+++ b/test/mochitest/browser_dbg-quick-open.js
@@ -121,6 +121,7 @@ add_task(async function() {
   info("Testing gotoSource");
   quickOpen(dbg, "sw1:5");
   pressKey(dbg, "Enter");
+  await waitForTime(150);
   await waitForSelectedSource(dbg, "switching-01");
   assertLine(dbg, 5);
 });


### PR DESCRIPTION
### Summary of Changes

* avoid allocating intermediary array
* use sets to avoid linear look-up
* debounce source transformations and filtering
* avoid unnecessary layout computations when scrolling

### Test Plan

- [x] Command-P opens the panel
- [x] Assert that searching yields the same results as before
- [x] Assert that opened tabs are shown by default