### PR TITLE
Update SecondaryPanes splitter

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -433,21 +433,19 @@ class SecondaryPanes extends Component<Props, State> {
 
   renderVerticalLayout() {
     return (
-      <div>
-        <SplitBox
-          initialSize="300px"
-          minSize={10}
-          maxSize="50%"
-          splitterSize={1}
-          startPanel={
-            <div style={{ width: "inherit" }}>
-              <WhyPaused delay={this.props.renderWhyPauseDelay} />
-              <Accordion items={this.getStartItems()} />
-            </div>
-          }
-          endPanel={<Accordion items={this.getEndItems()} />}
-        />
-      </div>
+      <SplitBox
+        initialSize="300px"
+        minSize={10}
+        maxSize="50%"
+        splitterSize={1}
+        startPanel={
+          <div style={{ width: "inherit" }}>
+            <WhyPaused delay={this.props.renderWhyPauseDelay} />
+            <Accordion items={this.getStartItems()} />
+          </div>
+        }
+        endPanel={<Accordion items={this.getEndItems()} />}
+      />
     );
   }
 


### PR DESCRIPTION
### Summary of Changes
 -Removed unnecessary div from SecondaryPanes.js that was causing the splitter from filling the box

Before:
![image1](https://user-images.githubusercontent.com/33161837/56559351-43c3a980-6556-11e9-9c6f-299e26d6841f.png)

After:
![image2](https://user-images.githubusercontent.com/33161837/56559398-6d7cd080-6556-11e9-91e6-9e82f071d57b.png)