### PR TITLE
refactor(components/editor): Allow one paint before updating the DOM

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -31,11 +31,23 @@ type Props = {
 
 class Breakpoint extends PureComponent<Props> {
   componentDidMount() {
-    this.addBreakpoint();
+    const props = this.props;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.addBreakpoint(props);
+      });
+    });
   }
 
   componentDidUpdate() {
-    this.addBreakpoint();
+    const props = this.props;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.addBreakpoint(props);
+      });
+    });
   }
 
   componentWillUnmount() {
@@ -112,8 +124,8 @@ class Breakpoint extends PureComponent<Props> {
     showMenu(event, breakpointItems(breakpoint, breakpointActions));
   };
 
-  addBreakpoint = () => {
-    const { breakpoint, editor, selectedSource } = this.props;
+  addBreakpoint = (props: Props) => {
+    const { breakpoint, editor, selectedSource } = props;
 
     // Hidden Breakpoints are never rendered on the client
     if (breakpoint.options.hidden) {

--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -45,15 +45,24 @@ export class DebugLine extends Component<Props> {
   componentDidUpdate(prevProps: Props) {
     const { why, frame, source } = this.props;
 
-    startOperation();
-    this.clearDebugLine(prevProps.why, prevProps.frame, prevProps.source);
-    this.setDebugLine(why, frame, source);
-    endOperation();
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        startOperation();
+        this.clearDebugLine(prevProps.why, prevProps.frame, prevProps.source);
+        this.setDebugLine(why, frame, source);
+        endOperation();
+      });
+    });
   }
 
   componentDidMount() {
     const { why, frame, source } = this.props;
-    this.setDebugLine(why, frame, source);
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.setDebugLine(why, frame, source);
+      });
+    });
   }
 
   componentWillUnmount() {

--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -61,11 +61,23 @@ export class HighlightLine extends Component<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    this.completeHighlightLine(prevProps);
+    const props = this.props;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.completeHighlightLine(props, prevProps);
+      });
+    });
   }
 
   componentDidMount() {
-    this.completeHighlightLine(null);
+    const props = this.props;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.completeHighlightLine(props, null);
+      });
+    });
   }
 
   shouldSetHighlightLine(
@@ -86,13 +98,13 @@ export class HighlightLine extends Component<Props> {
     return true;
   }
 
-  completeHighlightLine(prevProps: Props | null) {
+  completeHighlightLine(props: Props, prevProps: Props | null) {
     const {
       pauseCommand,
       selectedLocation,
       selectedFrame,
       selectedSource
-    } = this.props;
+    } = props;
     if (pauseCommand) {
       this.isStepping = true;
     }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -151,9 +151,9 @@ class Editor extends PureComponent<Props, State> {
 
     // Allow one paint before updating the DOM to feel responsive
     requestAnimationFrame(() => {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         this.setText(nextProps);
-        this.setSize(nextProps);
+        this.setSize(nextProps, prevProps);
         this.scrollToLocation(nextProps, prevProps);
       });
     });
@@ -271,25 +271,26 @@ class Editor extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    const props = this.props;
+
     // Allow one paint before updating the DOM to feel responsive
     requestAnimationFrame(() => {
-      setTimeout(() => {
-        const { selectedSource } = this.props;
+      requestAnimationFrame(() => {
         // NOTE: when devtools are opened, the editor is not set when
         // the source loads so we need to wait until the editor is
         // set to update the text and size.
-        if (!prevState.editor && selectedSource) {
+        if (!prevState.editor && props.selectedSource) {
           if (!this.state.editor) {
             const editor = this.setupEditor();
-            updateDocument(editor, selectedSource);
+            updateDocument(editor, props.selectedSource);
           } else {
-            this.setText(this.props);
-            this.setSize(this.props);
+            this.setText(props, prevProps);
+            this.setSize(props);
           }
         }
 
-        if (prevProps.selectedSource != selectedSource) {
-          this.props.updateViewport();
+        if (prevProps.selectedSource != props.selectedSource) {
+          props.updateViewport();
         }
       });
     });
@@ -542,14 +543,14 @@ class Editor extends PureComponent<Props, State> {
     }
   }
 
-  setSize(nextProps) {
+  setSize(nextProps: Props, prevProps: Props) {
     if (!this.state.editor) {
       return;
     }
 
     if (
-      nextProps.startPanelSize !== this.props.startPanelSize ||
-      nextProps.endPanelSize !== this.props.endPanelSize
+      nextProps.startPanelSize !== prevProps.startPanelSize ||
+      nextProps.endPanelSize !== prevProps.endPanelSize
     ) {
       this.state.editor.codeMirror.setSize();
     }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -143,7 +143,9 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    showLoading(this.state.editor);
+    if (nextProps.selectedSource !== this.props.selectedSource) {
+      showLoading(this.state.editor);
+    }
 
     // Allow one paint before updating the DOM to feel responsive
     requestAnimationFrame(() => {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -143,9 +143,16 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    this.setText(nextProps);
-    this.setSize(nextProps);
-    this.scrollToLocation(nextProps);
+    showLoading(this.state.editor);
+
+    // Allow one paint before updating the DOM to feel responsive
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        this.setText(nextProps);
+        this.setSize(nextProps);
+        this.scrollToLocation(nextProps);
+      });
+    });
   }
 
   setupEditor() {
@@ -260,23 +267,28 @@ class Editor extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { selectedSource } = this.props;
-    // NOTE: when devtools are opened, the editor is not set when
-    // the source loads so we need to wait until the editor is
-    // set to update the text and size.
-    if (!prevState.editor && selectedSource) {
-      if (!this.state.editor) {
-        const editor = this.setupEditor();
-        updateDocument(editor, selectedSource);
-      } else {
-        this.setText(this.props);
-        this.setSize(this.props);
-      }
-    }
+    // Allow one paint before updating the DOM to feel responsive
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        const { selectedSource } = this.props;
+        // NOTE: when devtools are opened, the editor is not set when
+        // the source loads so we need to wait until the editor is
+        // set to update the text and size.
+        if (!prevState.editor && selectedSource) {
+          if (!this.state.editor) {
+            const editor = this.setupEditor();
+            updateDocument(editor, selectedSource);
+          } else {
+            this.setText(this.props);
+            this.setSize(this.props);
+          }
+        }
 
-    if (prevProps.selectedSource != selectedSource) {
-      this.props.updateViewport();
-    }
+        if (prevProps.selectedSource != selectedSource) {
+          this.props.updateViewport();
+        }
+      });
+    });
   }
 
   getCurrentLine() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -147,12 +147,14 @@ class Editor extends PureComponent<Props, State> {
       showLoading(this.state.editor);
     }
 
+    const prevProps = this.props;
+
     // Allow one paint before updating the DOM to feel responsive
     requestAnimationFrame(() => {
       setTimeout(() => {
         this.setText(nextProps);
         this.setSize(nextProps);
-        this.scrollToLocation(nextProps);
+        this.scrollToLocation(nextProps, prevProps);
       });
     });
   }
@@ -501,8 +503,8 @@ class Editor extends PureComponent<Props, State> {
     );
   };
 
-  shouldScrollToLocation(nextProps) {
-    const { selectedLocation, selectedSource } = this.props;
+  shouldScrollToLocation(nextProps, prevProps) {
+    const { selectedLocation, selectedSource } = prevProps;
     const { editor } = this.state;
 
     if (
@@ -519,16 +521,16 @@ class Editor extends PureComponent<Props, State> {
       (!selectedSource || !isLoaded(selectedSource)) &&
       isLoaded(nextProps.selectedSource);
     const locationChanged = selectedLocation !== nextProps.selectedLocation;
-    const symbolsChanged = nextProps.symbols != this.props.symbols;
+    const symbolsChanged = nextProps.symbols != prevProps.symbols;
 
     return isFirstLoad || locationChanged || symbolsChanged;
   }
 
-  scrollToLocation(nextProps) {
+  scrollToLocation(nextProps, prevProps) {
     const { editor } = this.state;
     const { selectedLocation, selectedSource } = nextProps;
 
-    if (selectedLocation && this.shouldScrollToLocation(nextProps)) {
+    if (selectedLocation && this.shouldScrollToLocation(nextProps, prevProps)) {
       let { line, column } = toEditorPosition(selectedLocation);
 
       if (selectedSource && hasDocument(selectedSource.id)) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -284,8 +284,8 @@ class Editor extends PureComponent<Props, State> {
             const editor = this.setupEditor();
             updateDocument(editor, props.selectedSource);
           } else {
-            this.setText(props, prevProps);
-            this.setSize(props);
+            this.setText(props);
+            this.setSize(props, prevProps);
           }
         }
 

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -79,6 +79,14 @@ function render(overrides = {}) {
 }
 
 describe("Editor", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation(callback => callback());
+
+    jest.spyOn(window, "setTimeout").mockImplementation(callback => callback());
+  });
+
   describe("When empty", () => {
     it("should render", async () => {
       const { component } = render();
@@ -179,7 +187,7 @@ describe("Editor", () => {
         selectedLocation: { sourceId: "bar", line: 1, column: 1 }
       });
 
-      expect(mockEditor.replaceDocument.mock.calls[1][0].getValue()).toBe(
+      expect(mockEditor.replaceDocument.mock.calls[2][0].getValue()).toBe(
         "Loading…"
       );
 
@@ -204,6 +212,7 @@ describe("Editor", () => {
       await component.setProps({ ...props, selectedSource, symbols });
 
       expect(mockEditor.setMode.mock.calls).toEqual([
+        [{ name: "text" }],
         [{ name: "javascript" }],
         [{ name: "jsx" }]
       ]);
@@ -238,6 +247,7 @@ describe("Editor", () => {
       });
 
       expect(mockEditor.setMode.mock.calls).toEqual([
+        [{ name: "text" }],
         [{ name: "javascript" }],
         [{ name: "jsx" }]
       ]);

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -222,7 +222,7 @@ async function waitForElementWithSelector(dbg, selector) {
   return findElementWithSelector(dbg, selector);
 }
 
-async function waitForSelectedSource(dbg, url) {
+function waitForSelectedSource(dbg, url) {
   const {
     getSelectedSource,
     hasSymbols,
@@ -230,7 +230,7 @@ async function waitForSelectedSource(dbg, url) {
     hasBreakpointPositions
   } = dbg.selectors;
 
-  waitForState(
+  return waitForState(
     dbg,
     state => {
       const source = getSelectedSource(state);
@@ -256,8 +256,6 @@ async function waitForSelectedSource(dbg, url) {
     },
     "selected source"
   );
-
-  await waitForTime(150);
 }
 
 /**
@@ -635,7 +633,7 @@ async function selectSource(dbg, url, line) {
     { sourceId: source.id, line },
     { keepContext: false }
   );
-  return await waitForSelectedSource(dbg, url);
+  return waitForSelectedSource(dbg, url);
 }
 
 async function closeTab(dbg, url) {

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -772,7 +772,7 @@ async function addBreakpoint(dbg, source, line, column, options) {
   const bpCount = dbg.selectors.getBreakpointCount(dbg.getState());
   dbg.actions.addBreakpoint({ sourceId, line, column }, options);
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
-  await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve)));
+  await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
   is(
     dbg.selectors.getBreakpointCount(dbg.getState()),
     bpCount + 1,

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -772,6 +772,7 @@ async function addBreakpoint(dbg, source, line, column, options) {
   const bpCount = dbg.selectors.getBreakpointCount(dbg.getState());
   dbg.actions.addBreakpoint({ sourceId, line, column }, options);
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve)));
   is(
     dbg.selectors.getBreakpointCount(dbg.getState()),
     bpCount + 1,

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -222,7 +222,7 @@ async function waitForElementWithSelector(dbg, selector) {
   return findElementWithSelector(dbg, selector);
 }
 
-function waitForSelectedSource(dbg, url) {
+async function waitForSelectedSource(dbg, url) {
   const {
     getSelectedSource,
     hasSymbols,
@@ -230,7 +230,7 @@ function waitForSelectedSource(dbg, url) {
     hasBreakpointPositions
   } = dbg.selectors;
 
-  return waitForState(
+  waitForState(
     dbg,
     state => {
       const source = getSelectedSource(state);
@@ -256,6 +256,8 @@ function waitForSelectedSource(dbg, url) {
     },
     "selected source"
   );
+
+  await waitForTime(150);
 }
 
 /**
@@ -633,7 +635,7 @@ async function selectSource(dbg, url, line) {
     { sourceId: source.id, line },
     { keepContext: false }
   );
-  return waitForSelectedSource(dbg, url);
+  return await waitForSelectedSource(dbg, url);
 }
 
 async function closeTab(dbg, url) {


### PR DESCRIPTION
### Summary of Changes

Improves perceived responsiveness by rendering the loading state before freezing the UI. One of the things that makes the editor feel sluggish is that sometimes is _seems_ to not respond to clicks (e.g. you click on a tab or a file and nothing happens for a few seconds). This is because CodeMirror sometimes takes seconds to render the text, blocking the UI. This patch makes sure the editor responds immediately to the interaction by rendering the loading state before the UI is blocked by CodeMirror.

### Test Plan

Opened multiple sources, switched between tabs to make sure that they render.

Example test plan:

- [x] Command-P opens the panel
- [x] Select a large file (I've tested with a 2MB compressed JavaScript file)
- [x] Observe that the panel closes and "Loading..." is displayed (before the panel would stay opened until the source was rendered).

### Screenshots/Videos

#### Before (the UI freezes while the source is loaded, you can see the hover effect being visible for a few seconds)
![before](https://user-images.githubusercontent.com/2109702/57314393-d71de280-70f1-11e9-9044-78e7a10ebb4d.gif)

#### After (the UI freezes while the source is loaded but the "Loading..." message is displayed first - the hover effect also dissapears)
![after](https://user-images.githubusercontent.com/2109702/57314247-902fed00-70f1-11e9-9897-d986402e0858.gif)


