### PR TITLE
Improve readability of stepping button tool tips labels

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -69,7 +69,7 @@ function formatKey(action) {
     const winKey =
       getKeyForOS("WINNT", `${action}Display`) || getKeyForOS("WINNT", action);
     // display both Windows type and Mac specific keys
-    return formatKeyShortcut([key, winKey].join(" "));
+    return formatKeyShortcut(`(${key} or ${winKey})`);
   }
   return formatKeyShortcut(key);
 }


### PR DESCRIPTION
Fixes #6993

I've been away a while so I thought I would try an easy one to get reacquainted with the project.  It looks like no one has touched this in 3 months so I took it.  I hope you don't mind.

### Summary of Changes
* Add parenthesis and 'or' to step button tool tips to make them more readable

**Before**
![](http://g.recordit.co/LN4Sqs6Jt6.gif)
**After**
![](http://g.recordit.co/rtYHyF7wtq.gif)