### PR TITLE
Indicate shadowed object inspector items in the UI

### DIFF
--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspector.css
@@ -35,6 +35,11 @@
   line-height: 14px;
 }
 
+.tree.object-inspector .object-shadowed {
+  text-decoration: line-through;
+  color: var(--theme-comment);
+}
+
 .object-inspector .object-delimiter {
   color: var(--theme-comment);
   white-space: pre-wrap;

--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js
@@ -267,9 +267,11 @@ class ObjectInspectorItem extends Component<Props> {
     }
 
     const { item, depth, focused, expanded, onLabelClick } = this.props;
+    const shadowedName = item.shadowed ? " object-shadowed" : "";
+    const className = `object-label${shadowedName}`;
     return dom.span(
       {
-        className: "object-label",
+        className,
         onClick: onLabelClick
           ? event => {
               event.stopPropagation();


### PR DESCRIPTION
Show a strikethrough and shadowed color for ObjectInspector items that have been marked as shadowed.  Accompanies bug 1448166.