### PR TITLE
Updated Readme reference to Google Doc sheet for Discussion Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Say hello in [Slack][slack] or in the [#devtools-html][irc-devtools-html] channe
 [logging]: ./docs/local-development.md#logging
 [testing]: ./docs/local-development.md#testing
 [linting]: ./docs/local-development.md#linting
-[google-docs]: https://docs.google.com/document/d/146p7Y8Ues_AKjj4ReWCk6InOPWe3C3Koy6EQ1qnYKNM/edit
+[google-docs]: https://docs.google.com/document/d/1lxy0IzUM14dYACk_q862vVYwpU1AA4NQVrUNAm6uc-8/edit#heading=h.onwi5ko98n17
 [cl]: ./docs/issues.md#claiming-issues
 [firefox-nightly]: ./docs/getting-setup.md#starting-firefox-nightly


### PR DESCRIPTION
Fixes #8248

### Summary of Changes

* Changed `google-docs` reference to the most recent Google Docs sheet

### Test Plan

1. I clicked through the links on the old Google Docs that reference the new Google Docs until I got to a document that didn't have a reference to a new one
2. I verified the dates on this document were recent
3. I copied the URL
4. I pasted the new URL at the bottom of the readme for the `google-docs` ref
