### PR TITLE
Pass the object to onDOMNodeMouseOut in the reps (#8258)

### DIFF
--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -65,7 +65,7 @@ function ElementNode(props) {
 
     if (onDOMNodeMouseOut) {
       Object.assign(baseConfig, {
-        onMouseOut: onDOMNodeMouseOut
+        onMouseOut: _ => onDOMNodeMouseOut(object)
       });
     }
 

--- a/packages/devtools-reps/src/reps/tests/element-node.js
+++ b/packages/devtools-reps/src/reps/tests/element-node.js
@@ -160,6 +160,7 @@ describe("ElementNode - Node", () => {
     renderedComponent.simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(1);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toEqual(stub);
   });
 
   it("calls the expected function when mouseover is fired on Rep", () => {

--- a/packages/devtools-reps/src/reps/tests/event.js
+++ b/packages/devtools-reps/src/reps/tests/event.js
@@ -126,6 +126,7 @@ describe("Event - mouse event", () => {
     node.simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(1);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toEqual(grips[0]);
   });
 
   it("calls the expected function when mouseover is fired on Rep", () => {

--- a/packages/devtools-reps/src/reps/tests/grip-array.js
+++ b/packages/devtools-reps/src/reps/tests/grip-array.js
@@ -386,6 +386,9 @@ describe("GripArray - NodeList", () => {
     node.at(2).simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(3);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toBe(grips[0]);
+    expect(onDOMNodeMouseOut.mock.calls[1][0]).toBe(grips[1]);
+    expect(onDOMNodeMouseOut.mock.calls[2][0]).toBe(grips[2]);
   });
 
   it("calls the expected function on click", () => {

--- a/packages/devtools-reps/src/reps/tests/grip-map-entry.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map-entry.js
@@ -147,6 +147,7 @@ describe("GripMapEntry - complex", () => {
 
     node.simulate("mouseout");
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(1);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toEqual(stub);
 
     node.simulate("mouseover");
     expect(onDOMNodeMouseOver.mock.calls).toHaveLength(1);
@@ -172,6 +173,7 @@ describe("GripMapEntry - complex", () => {
 
     node.simulate("mouseout");
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(2);
+    expect(onDOMNodeMouseOut.mock.calls[1][0]).toEqual(stub);
 
     node.simulate("mouseover");
     expect(onDOMNodeMouseOver.mock.calls).toHaveLength(2);

--- a/packages/devtools-reps/src/reps/tests/grip-map.js
+++ b/packages/devtools-reps/src/reps/tests/grip-map.js
@@ -236,6 +236,9 @@ describe("GripMap - Node-keyed entries", () => {
     node.at(2).simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(3);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toBe(grips[0]);
+    expect(onDOMNodeMouseOut.mock.calls[1][0]).toBe(grips[1]);
+    expect(onDOMNodeMouseOut.mock.calls[2][0]).toBe(grips[2]);
   });
 
   it("calls the expected function on click", () => {
@@ -292,6 +295,9 @@ describe("GripMap - Node-valued entries", () => {
     node.at(2).simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(3);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toBe(grips[0]);
+    expect(onDOMNodeMouseOut.mock.calls[1][0]).toBe(grips[1]);
+    expect(onDOMNodeMouseOut.mock.calls[2][0]).toBe(grips[2]);
   });
 
   it("calls the expected function on click", () => {

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -380,6 +380,8 @@ describe("Grip - Object with connected nodes", () => {
     node.at(1).simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(2);
+    expect(onDOMNodeMouseOut.mock.calls[0][0]).toBe(grips[0]);
+    expect(onDOMNodeMouseOut.mock.calls[1][0]).toBe(grips[1]);
   });
 
   it("calls the expected function on click", () => {

--- a/packages/devtools-reps/src/reps/tests/promise.js
+++ b/packages/devtools-reps/src/reps/tests/promise.js
@@ -129,6 +129,7 @@ describe("Promise - fulfilled with node", () => {
     node.simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(1);
+    expect(onDOMNodeMouseOut).toBeCalledWith(grips[0]);
   });
 
   it("no inspect icon when the node is not connected to the DOM tree", () => {

--- a/packages/devtools-reps/src/reps/tests/text-node.js
+++ b/packages/devtools-reps/src/reps/tests/text-node.js
@@ -70,6 +70,7 @@ describe("TextNode", () => {
     wrapper.simulate("mouseout");
 
     expect(onDOMNodeMouseOut.mock.calls).toHaveLength(1);
+    expect(onDOMNodeMouseOut).toBeCalledWith(object);
   });
 
   it("displays a button when the node is connected", () => {

--- a/packages/devtools-reps/src/reps/text-node.js
+++ b/packages/devtools-reps/src/reps/text-node.js
@@ -49,7 +49,7 @@ function TextNode(props) {
 
     if (onDOMNodeMouseOut) {
       Object.assign(baseConfig, {
-        onMouseOut: onDOMNodeMouseOut
+        onMouseOut: _ => onDOMNodeMouseOut(grip)
       });
     }
 


### PR DESCRIPTION
Fixes #98258

### Summary of Changes

* Passes the object to onDOMNodeMouseOut in the reps
